### PR TITLE
KVIB-116: Fiks react-bygg

### DIFF
--- a/.changeset/three-eggs-admire.md
+++ b/.changeset/three-eggs-admire.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Inkluder dist-mappen i turbobygg

--- a/package-lock.json
+++ b/package-lock.json
@@ -33184,7 +33184,7 @@
     },
     "packages/css": {
       "name": "@kvib/css",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT"
     },
     "packages/kvib-react-button": {
@@ -33208,7 +33208,7 @@
     },
     "packages/react": {
       "name": "@kvib/react",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",

--- a/turbo.json
+++ b/turbo.json
@@ -1,16 +1,15 @@
 {
-    "$schema": "https://turbo.build/schema.json",
-    "pipeline": {
-      "build": {
-        "dependsOn": ["^build"],
-        "outputs": ["build/**"]
-      },
-      "lint": {
-        "outputs": []
-      },
-      "dev": {
-        "cache": false
-      }
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "dev": {
+      "cache": false
     }
   }
-  
+}


### PR DESCRIPTION
# Beskrivelse
React-pakken ble publisert til npm, men den inkluderer ikke dist-filene. Prøver å finne ut hva feilen kan være, tror npm publish-greiene fungerer greit, men man må ha bygget filene for at den skal ha noe å publiere. Tror derfor feilen ligger i turbo, forhåpentligvis er det ikke for mye styr å fikse.