### PR TITLE
KVIB-116: Legger til npmignore for å prøve å fikse react-bygg

### DIFF
--- a/.changeset/silent-feet-kick.md
+++ b/.changeset/silent-feet-kick.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Arbitrær endring for å utløse ny publisering

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/react/src/button/style.css
+++ b/packages/react/src/button/style.css
@@ -6,7 +6,7 @@
   font-family: "Mulish", sans-serif;
   font-style: normal;
   font-weight: 700;
-  font-size: 18px;
+  font-size: 1rem;
   line-height: 28px;
   border-radius: 8px;
   color: #ffffff;


### PR DESCRIPTION
# Beskrivelse
[Forrige runde](https://github.com/kartverket/kvib/pull/178) gjorde ikke susen, så vi prøver igjen. Når vi kjører dry-run av publish ser det ut til å fungere, så vi mistenker at det er bygget som ikke fungerer. Alt av logger tyder på at de gjør som de skal.

`npm publish` baserer seg visst på gitignore dersom man ikke har en egen npmignore, som virker litt merkelig. Fra det jeg har sett på andre turbo-repoer ser ikke dette ut til å være et problem, så tviler litt på at dette fikser saken.