### PR TITLE
Forsøk på å fikse storybook og redirect til kvib-old

### DIFF
--- a/.changeset/curly-carpets-compare.md
+++ b/.changeset/curly-carpets-compare.md
@@ -1,5 +1,0 @@
----
-"@kvib/css": minor
----
-
-Avmerkingsboks har nå en egen feilmelding, samt andre små forandringer

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
-          publish_dir: ./apps/docusaurus/build
+          publish_dir: ./apps/storybook/storybook-static
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ _site/
 **/dist
 
 # Generated files
-.docusaurus
 .cache-loader
 .turbo
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,7 +21,6 @@ _site/
 **/dist
 
 # Generated files
-.docusaurus
 .cache-loader
 .turbo
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/apps/storybook/index.html
+++ b/apps/storybook/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Redirecting https://kartverket.github.io/kvib-old</title>
-<meta http-equiv="refresh" content="0; Uhttps://kartverket.github.io/kvib-old" />
+<meta http-equiv="refresh" content="0; https://kartverket.github.io/kvib-old" />
 <link rel="canonical" hrehttps://kartverket.github.io/kvib-old">

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "storybook dev -p 6006",
-    "build": "storybook build"
+    "build": "storybook build",
+    "postbuild": "mv storybook-static/index.html storybook-static/storybook.html && cp index.html storybook-static/index.html"
   },
   "keywords": [],
   "author": "",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "storybook",
+  "name": "@kvib/storybook",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
# Beskrivelse

- Fjerner gammelt changeset for css-pakken som crasher release
- Endrer hvilken mappe som skal deployes til github-pages
- Passer på at redirect-filen kommer med byggemappen til deploy
- Renamer den lokale pakken apps/storybook for å unngå navnekonflikt i turbo
