### PR TITLE
Fikser manglende sync mellom package og package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       }
     },
     "apps/storybook": {
+      "name": "@kvib/storybook",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
@@ -4354,6 +4355,10 @@
     },
     "node_modules/@kvib/react": {
       "resolved": "packages/react",
+      "link": true
+    },
+    "node_modules/@kvib/storybook": {
+      "resolved": "apps/storybook",
       "link": true
     },
     "node_modules/@manypkg/find-root": {
@@ -17514,10 +17519,6 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
       "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
       "dev": true
-    },
-    "node_modules/storybook": {
-      "resolved": "apps/storybook",
-      "link": true
     },
     "node_modules/stream-shift": {
       "version": "1.0.1",


### PR DESCRIPTION
# Beskrivelse

Forrige PR tok package.json og package-lock ut av sync etter at jeg renamet apps/storybook, denne fiksen gjør at man kan bruke npm ci igjen.