### PR TITLE
Videresend et par theme-utils

### DIFF
--- a/.changeset/thick-stingrays-develop.md
+++ b/.changeset/thick-stingrays-develop.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Videresender et par funksjoner fra theme-utils (extendTheme og withDefaultColorScheme)

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -47,6 +47,7 @@ export * from "./tabs";
 export * from "./tag";
 export * from "./textarea";
 export * from "./theme";
+export * from "./theme-utils";
 export * from "./toast";
 export * from "./tooltip";
 export * from "./transitions";

--- a/packages/react/src/theme-utils/index.ts
+++ b/packages/react/src/theme-utils/index.ts
@@ -1,0 +1,1 @@
+export { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";


### PR DESCRIPTION
Vi bruker et par funksjoner fra [@chakra-ui/theme-utils](https://github.com/chakra-ui/chakra-ui/tree/main/packages/utilities/theme-utils) for å sette blå som standardtema i Nibas:

```
import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";

const customTheme = extendTheme(
  withDefaultColorScheme({ colorScheme: "blue" }),
  theme
);
```

Vi vil helst unngå å importere fra chakra for å unngå potensiell krøll, så det hadde vært kjekt å heller bare ha de funksjonene videresendt fra kvib

Alternative løsninger:
- Sette blå som standardtema i kvib dersom det er flere som bruker blå enn grønn (hvilke konsumenter av kvib bruker grønn per nå? Det krever noe innsikt for å avgjøre)
- La KvibProvider ta imot default-temanavn som en parameter i stedet, så slipper konsumentene å skrive kodesnutten over. 
