### PR TITLE
🐛 KOMP-181-button-warning

### DIFF
--- a/.changeset/pink-ligers-draw.md
+++ b/.changeset/pink-ligers-draw.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Rydder opp i button slik at den ikke lenger har en warning om iconFill.

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -42,7 +42,6 @@ export const Button = forwardRef<ButtonProps, "button">(
         colorScheme={finalColorScheme}
         isDisabled={isDisabled || isLoading}
         aria-busy={isLoading}
-        iconFill={iconFill && (rightIcon || leftIcon)}
       >
         {isLoading && (
           <Center position="absolute" right="0" left="0">


### PR DESCRIPTION
# Beskrivelse

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->

Fjerner prop på Button som skapte warning. Chakrabutton har ikke propen, så er nok bare en mistake fra tidligere. 

<img width="442" alt="Screenshot 2023-07-27 at 15 22 44" src="https://github.com/kartverket/kvib/assets/42931448/7a043d17-dd36-4d62-9d08-06ff17d6f867">



<!-- Sjekk av disse punktene for hver endring -->


