### PR TITLE
🐛 KOMP-184-buttonBug

### DIFF
--- a/.changeset/new-spoons-suffer.md
+++ b/.changeset/new-spoons-suffer.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Button med variant="outline" vil ikke lenger endre størrelse ved hover.

--- a/packages/react/src/theme/components/button.ts
+++ b/packages/react/src/theme/components/button.ts
@@ -75,7 +75,7 @@ export const variantOutline = defineStyle((props) => {
     borderColor: `${c}.500`,
     color: `${c}.500`,
     _hover: {
-      border: "0px",
+      borderColor: `${c}.400`,
       bg: `${c}.400`,
       color: colors.white,
       _disabled: {


### PR DESCRIPTION
# Beskrivelse

Button (variant=outline) hopper litt på focus -> Ikke fjerne border, men heller sette den til samme farge som bakgrunnen.

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->

