### PR TITLE
Komp-186-stat

### DIFF
--- a/.changeset/rich-apes-sparkle.md
+++ b/.changeset/rich-apes-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+Oppdaterer dokumentasjon for Stat.

--- a/apps/storybook/stories/components/data-display/stat/Stat.mdx
+++ b/apps/storybook/stories/components/data-display/stat/Stat.mdx
@@ -1,13 +1,22 @@
-import { Meta } from "@storybook/blocks";
+import { Meta, Canvas, Story, Controls } from "@storybook/blocks";
+import * as StatStories from "./Stat.stories";
 
 <Meta title="Komponenter/Data Display/Stat" />
 
 # Stat
 
-Se [https://chakra-ui.com/docs/components/stat](https://chakra-ui.com/docs/components/stat) for eksempler og dokumentasjon.
+Stat-komponentet brukes til å vise frem statistikk.
 
 ## Ta i bruk
 
 ```jsx
 import { Stat, StatLabel, StatNumber, StatHelpText, StatArrow, StatGroup } from "@kvib/react";
 ```
+
+## Props
+
+<Canvas of={StatStories.Stat} />
+
+## Stat med indikator
+
+<Canvas of={StatStories.StatIndicator} />

--- a/apps/storybook/stories/components/data-display/stat/Stat.stories.tsx
+++ b/apps/storybook/stories/components/data-display/stat/Stat.stories.tsx
@@ -1,0 +1,59 @@
+import {
+  Stat as KvibStat,
+  StatLabel as KvibStatLabel,
+  StatNumber as KvibStatNumber,
+  StatHelpText as KvibStatHelpText,
+  StatArrow as KvibStatArrow,
+  StatGroup as KvibStatGroup,
+} from "@kvib/react/src";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof KvibStat> = {
+  title: "Komponenter/Data Display/Stat",
+  component: KvibStat,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: "shown" },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof KvibStat>;
+
+export const Stat: Story = {
+  args: {},
+  render: (args) => (
+    <KvibStat {...args}>
+      <KvibStatLabel>Utgifter</KvibStatLabel>
+      <KvibStatNumber>3200kr</KvibStatNumber>
+      <KvibStatHelpText>Feb 12 - Feb 28</KvibStatHelpText>
+    </KvibStat>
+  ),
+};
+
+export const StatIndicator: Story = {
+  args: {},
+  render: (args) => (
+    <KvibStatGroup>
+      <KvibStat {...args}>
+        <KvibStatLabel>Sendt</KvibStatLabel>
+        <KvibStatNumber>345,670</KvibStatNumber>
+        <KvibStatHelpText>
+          <KvibStatArrow type="increase" />
+          23.36%
+        </KvibStatHelpText>
+      </KvibStat>
+
+      <KvibStat {...args}>
+        <KvibStatLabel>Klikk</KvibStatLabel>
+        <KvibStatNumber>45</KvibStatNumber>
+        <KvibStatHelpText>
+          <KvibStatArrow type="decrease" />
+          9.05%
+        </KvibStatHelpText>
+      </KvibStat>
+    </KvibStatGroup>
+  ),
+};


### PR DESCRIPTION
# Beskrivelse

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->

Legger til dokumentasjon for stat.

<img width="1094" alt="Screenshot 2023-08-01 at 09 42 41" src="https://github.com/kartverket/kvib/assets/42931448/12c3ad40-08d6-4294-a4e6-e64eb883f751">


# Sjekkliste

<!-- Sjekk av disse punktene for hver endring -->

- [x] Sjekket universell utforming for komponenten. Se for eksempel:
  - https://www.magentaa11y.com/web/
  - https://a11y-101.com/development
  - https://www.a11yproject.com/checklist/#appearance
- [x] Denne PR-en inneholder en enkelt komponent
