### PR TITLE
KOMP-205-linkOverlay

### DIFF
--- a/apps/storybook/stories/components/link-overlay/LinkOverlay.mdx
+++ b/apps/storybook/stories/components/link-overlay/LinkOverlay.mdx
@@ -1,13 +1,47 @@
-import { Meta } from "@storybook/blocks";
+import { Meta, Canvas, Story, Controls, Source } from "@storybook/blocks";
+import * as LinkOverlayStories from "./LinkOverlay.stories";
 
-<Meta title="Komponenter/Link Overlay" />
+<Meta of={LinkOverlayStories} />
 
 # Link Overlay
 
-Se [https://chakra-ui.com/docs/components/link-overlay](https://chakra-ui.com/docs/components/link-overlay) for eksempler og dokumentasjon.
+Link Overlay er et semantisk komponent som brukes til å wrappe elementer sammen i en link.
 
 ## Ta i bruk
 
 ```jsx
 import { LinkBox, LinkOverlay } from "@kvib/react";
 ```
+
+## Props
+
+<Canvas of={LinkOverlayStories.LinkOverlay} />
+<Controls of={LinkOverlayStories.LinkOverlay} />
+
+## Nested link
+
+<Canvas of={LinkOverlayStories.LinkOverlayNested} />
+
+## Link Overlay med Routing Library
+
+For å legge til støtte for biblioteker som Next.js eller gatsby Link må du wrappe de rundt `LinkOverlay` eller bruke de som en prop.
+
+<Source
+  code={`const RoutingExample = () => {
+  return (
+    <LinkBox as="article">
+      <h2>
+        <LinkOverlay as={NextLink} href="#">
+          Some blog post
+        </LinkOverlay>
+      </h2>
+      <p>
+        As a side note, using quotation marks around an attribute value is required only if this value is not a valid
+        identifier.
+      </p>
+      <a href="#">Some inner link</a>
+    </LinkBox>
+  );
+};`}
+  dark
+/>

--- a/apps/storybook/stories/components/link-overlay/LinkOverlay.stories.tsx
+++ b/apps/storybook/stories/components/link-overlay/LinkOverlay.stories.tsx
@@ -1,0 +1,75 @@
+import {
+  Box as KvibBox,
+  Heading as KvibHeading,
+  LinkBox as KvibLinkBox,
+  LinkOverlay as KvibLinkOverlay,
+  Text as KvibText,
+} from "@kvib/react/src";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof KvibLinkOverlay> = {
+  title: "Komponenter/LinkOverlay",
+  component: KvibLinkOverlay,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: "shown" },
+    },
+  },
+  argTypes: {
+    isExternal: {
+      description: "If true, the link will open in new tab",
+      table: {
+        type: { summary: Boolean },
+        defaultValue: { summary: false },
+      },
+      control: "boolean",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof KvibLinkOverlay>;
+
+export const LinkOverlay: Story = {
+  args: {},
+  render: (args) => (
+    <KvibLinkBox as="article" maxW="sm" p="5" borderWidth="1px" rounded="md">
+      <KvibBox as="time" dateTime="2021-01-15 15:30:00 +0000 UTC">
+        13 timer siden
+      </KvibBox>
+      <KvibHeading size="md" my="2">
+        <KvibLinkOverlay {...args} href="#">
+          Ikke gå deg vill på bærtur
+        </KvibLinkOverlay>
+      </KvibHeading>
+      <KvibText>
+        Bær- og soppsesongen er i full gang til skogs og fjells. Last ned Kartverkets gratis mobil-app "Hvor?", så vet
+        du hvor du er.
+      </KvibText>
+    </KvibLinkBox>
+  ),
+};
+
+export const LinkOverlayNested: Story = {
+  args: {},
+  render: (args) => (
+    <KvibLinkBox as="article" maxW="sm" p="5" borderWidth="1px" rounded="md">
+      <KvibBox as="time" dateTime="2021-01-15 15:30:00 +0000 UTC">
+        13 timer siden
+      </KvibBox>
+      <KvibHeading size="md" my="2">
+        <KvibLinkOverlay {...args} href="#">
+          Ikke gå deg vill på bærtur
+        </KvibLinkOverlay>
+      </KvibHeading>
+      <KvibText mb="3">
+        Bær- og soppsesongen er i full gang til skogs og fjells. Last ned Kartverkets gratis mobil-app "Hvor?", så vet
+        du hvor du er.
+      </KvibText>
+      <KvibBox as="a" color="teal.400" href="#" fontWeight="bold">
+        En ekstra link
+      </KvibBox>
+    </KvibLinkBox>
+  ),
+};


### PR DESCRIPTION
# Beskrivelse

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->

Legger til dokumentasjon for LinkOverlay.

<img width="1066" alt="Screenshot 2023-08-08 at 12 41 02" src="https://github.com/kartverket/kvib/assets/42931448/763e0290-3592-4fb7-b052-8086c5a7a02a">


# Sjekkliste

<!-- Sjekk av disse punktene for hver endring -->

- [ ] Sjekket universell utforming for komponenten. Se for eksempel:
  - https://www.magentaa11y.com/web/
  - https://a11y-101.com/development
  - https://www.a11yproject.com/checklist/#appearance
- [ ] Denne PR-en inneholder en enkelt komponent
