### PR TITLE
Komp-210-chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,7 @@ name: "Chromatic"
 # Event for the workflow
 on:
   pull_request:
-    types: [opened, labeled, synchronize]
+    types: [labeled]
 
 # List of jobs
 jobs:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,6 @@ name: "Chromatic"
 # Event for the workflow
 on:
   pull_request:
-    branches: ["master"]
     types: [opened, labeled, synchronize]
 
 # List of jobs

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,9 +5,9 @@ name: "Chromatic"
 
 # Event for the workflow
 on:
-  push:
-    tags:
-      - chromatic-build
+  pull_request:
+    branches: ["master"]
+    types: [opened, labeled, synchronize]
 
 # List of jobs
 jobs:
@@ -23,6 +23,7 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         # Chromatic GitHub Action options
+        if: (contains(github.event.pull_request.labels.*.name, 'run_chromatic')
         with:
           workingDir: ./apps/storybook
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         # Chromatic GitHub Action options
-        if: (contains(github.event.pull_request.labels.*.name, 'run_chromatic')
+        if: (contains(github.event.pull_request.labels.*.name, 'chromatic'))
         with:
           workingDir: ./apps/storybook
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.

--- a/apps/storybook/stories/documentation/bidra/Teste.mdx
+++ b/apps/storybook/stories/documentation/bidra/Teste.mdx
@@ -68,13 +68,7 @@ og sørge for at hvert nytt komponent samsvarer med våre designstandarder.
 
 Når et komponent er ferdig og klart til å bli sjekket av designer, kan et nytt build bli publisert til Chromatic:
 
-1. Lag en ny tag i git (Trenger bare å bli gjort første gang): `git tag -a chromatic-build -m "Build with Chromatic"`
-
-2. Add og commit endringer.
-
-3. Push endringer med tag: `git push origin <branch_name> chromatic-build`.
-
-- Dersom Chromatic-action ikke kjører, må du overskrive tag i remote: `git push origin chromatic-build -f`.
+**Dette gjøres ved å legge til `chromatic` som label i PRen.**
 
 Dette vil trigge en Github Action som vil publisere til Chromatic. I tillegg blir det lagt til en pull request check som inneholder link til Chromatic.
 Her må PRen godkjennes for at det skal være mulig å merge den inn i master.


### PR DESCRIPTION
Endrer chromatic til å kjøre når man legger til label "chromatic" på en PR. Dette gjør det enklere å lage et build til chromatic. Nå har jeg skrudd av UI-tests i chromatic - vet ikke om vi trenger de egentlig. Dette gjør at det ikke blir like mange snapshots. Vi har fortsatt UI-review, så får vi se hvordan det fungerer😎