### PR TITLE
KOMP-214-formControlbug

### DIFF
--- a/.changeset/sharp-phones-sparkle.md
+++ b/.changeset/sharp-phones-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Legger til gap i feilmelding på Form Control.

--- a/packages/react/src/form-control/Form-error-message.tsx
+++ b/packages/react/src/form-control/Form-error-message.tsx
@@ -22,6 +22,7 @@ export const FormErrorMessage = forwardRef<FormErrorMessageProps, "div">(
         borderColor={"red.100"}
         borderWidth={"2px"}
         borderRadius={"8px"}
+        gap="5px"
       >
         <span className={"material-symbols-outlined"}>Error</span>
         <ChakraText>


### PR DESCRIPTION
# Beskrivelse

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->

Legger til gap i feilmelding på form control. Det var ingen plass mellom ikon og tekst før.

<img width="264" alt="Screenshot 2023-08-14 at 10 20 05" src="https://github.com/kartverket/kvib/assets/42931448/7e797b10-b1a6-415d-8825-17d6b6972aa8">


