### PR TITLE
Samkjører standard fargetema på tvers av komponenter

### DIFF
--- a/apps/storybook/stories/components/checkbox/Checkbox.stories.tsx
+++ b/apps/storybook/stories/components/checkbox/Checkbox.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof KvibCheckbox> = {
       description: "The color of the Checkbox",
       table: {
         type: { summary: "green | blue" },
-        defaultValue: { summary: "blue" },
+        defaultValue: { summary: "green" },
       },
       control: "radio",
       options: ["green", "blue"],
@@ -55,9 +55,6 @@ type Story = StoryObj<typeof KvibCheckbox>;
 export const Checkbox: Story = {
   args: {
     children: "Dette er en avmerkingsboks",
-    colorScheme: "green",
-    size: "md",
-    isDisabled: false,
   },
   render: (args) => <KvibCheckbox {...args}>{args.children}</KvibCheckbox>,
 };

--- a/apps/storybook/stories/components/icon-button/IconButton.mdx
+++ b/apps/storybook/stories/components/icon-button/IconButton.mdx
@@ -19,7 +19,7 @@ Her er en oversikt over utvalget av ikonknapper i Kartverkets Designbibliotek. D
 ## Ta i bruk
 
 ```jsx
-import { Button } from "@kvib/react";
+import { IconButton } from "@kvib/react";
 ```
 
 ## Props

--- a/apps/storybook/stories/components/range-slider/RangeSlider.stories.tsx
+++ b/apps/storybook/stories/components/range-slider/RangeSlider.stories.tsx
@@ -227,7 +227,6 @@ export const RangeSliderColors: Story = {
 export const RangeSliderOrientation: Story = {
   args: {
     defaultValue: [20, 60],
-    colorScheme: "green",
     minH: "32",
     orientation: "vertical",
   },

--- a/apps/storybook/stories/components/select/Select.mdx
+++ b/apps/storybook/stories/components/select/Select.mdx
@@ -1,13 +1,35 @@
-import { Meta } from "@storybook/blocks";
+import { Meta, Canvas, Story, Controls } from "@storybook/blocks";
+import * as SelectStories from "./Select.stories";
 
-<Meta title="Komponenter/Select" />
+<Meta of={SelectStories} />
 
 # Select
 
-Se [https://chakra-ui.com/docs/components/select](https://chakra-ui.com/docs/components/select) for eksempler og dokumentasjon.
+Select er et komponent som gjør at brukere kan velge verdier fra forhåndsdefinerte alternativer.
 
 ## Ta i bruk
 
 ```jsx
 import { Select } from "@kvib/react";
 ```
+
+## Props
+
+<Canvas of={SelectStories.Select} />
+<Controls of={SelectStories.Select} />
+
+## Størrelser
+
+<Canvas of={SelectStories.SelectSizes} />
+
+## Varianter
+
+<Canvas of={SelectStories.SelectVariants} />
+
+## Endre ikon
+
+<Canvas of={SelectStories.SelectIcon} />
+
+## Overstyring av stil
+
+<Canvas of={SelectStories.SelectStyles} />

--- a/apps/storybook/stories/components/select/Select.stories.tsx
+++ b/apps/storybook/stories/components/select/Select.stories.tsx
@@ -1,0 +1,195 @@
+import { Icon, Select as KvibSelect, Stack as KvibStack } from "@kvib/react/src";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof KvibSelect> = {
+  title: "Komponenter/Select",
+  component: KvibSelect,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: "shown" },
+    },
+  },
+  argTypes: {
+    colorScheme: {
+      description: "The visual color appearance of the component",
+      table: {
+        type: {
+          summary: '"green" | "blue" | "red" | "gray"',
+        },
+      },
+      options: ["green", "blue", "red", "gray"],
+      control: "select",
+    },
+
+    errorBorderColor: {
+      description: "The border color when the select is invalid. Use color keys in `theme.colors`",
+      table: {
+        type: { summary: "string" },
+      },
+      control: "text",
+    },
+
+    focusBorderColor: {
+      description: "The border color when the select is focused. Use color keys in `theme.colors`",
+      table: {
+        type: { summary: "string" },
+      },
+      control: "text",
+    },
+
+    icon: {
+      description: "The icon element to use in the select",
+      table: {
+        type: { summary: "ReactElement<any, string | JSXElementConstructor<any>>" },
+      },
+      control: "text",
+    },
+
+    iconColor: {
+      description: "The color of the icon",
+      table: {
+        type: { summary: "string" },
+      },
+      control: "text",
+    },
+
+    iconSize: {
+      description: "The size (width and height) of the icon",
+      table: {
+        type: { summary: "string" },
+      },
+      control: "text",
+    },
+
+    isDisabled: {
+      description: "",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: false },
+      },
+      control: "boolean",
+    },
+
+    isInvalid: {
+      description:
+        "If true, the form control will be invalid. This has 2 side effects: - The FormLabel and FormErrorIcon will have `data-invalid` set to true - The form element (e.g, Input) will have `aria-invalid` set to true",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: false },
+      },
+      control: "boolean",
+    },
+
+    isReadOnly: {
+      description: "If true, the form control will be readonly",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: false },
+      },
+      control: "boolean",
+    },
+
+    isRequired: {
+      description:
+        "If true, the form control will be required. This has 2 side effects: - The FormLabel will show a required indicator - The form element (e.g, Input) will have `aria-required` set to true",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: false },
+      },
+      control: "boolean",
+    },
+
+    rootProps: {
+      description: "Props to forward to the root div element",
+      table: {
+        type: { summary: "RootProps" },
+      },
+      control: "text",
+    },
+
+    size: {
+      description: "The size of the Select",
+      table: {
+        type: { summary: '"lg" | "md" | "sm" | "xs"' },
+        defaultValue: { summary: "md" },
+      },
+      options: ["lg", "md", "sm", "xs"],
+      control: "radio",
+    },
+
+    variant: {
+      description: "The variant of the Select",
+      table: {
+        type: { summary: '"outline" | "filled" | "flushed" | "unstyled"' },
+        defaultValue: { summary: "outline" },
+      },
+      options: ["outline", "filled", "flushed", "unstyled"],
+      control: "radio",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof KvibSelect>;
+
+export const Select: Story = {
+  args: {},
+  render: (args) => (
+    <KvibSelect {...args} placeholder="Velg alternativ" aria-label="select">
+      <option value="option1">Alternativ 1</option>
+      <option value="option2">Alternativ 2</option>
+      <option value="option3">Alternativ 3</option>
+    </KvibSelect>
+  ),
+};
+
+export const SelectSizes: Story = {
+  args: {},
+  render: (args) => (
+    <KvibStack spacing={3}>
+      <KvibSelect {...args} placeholder="extra small" size="xs" aria-label="select extra small" />
+      <KvibSelect {...args} placeholder="small" size="sm" aria-label="select small" />
+      <KvibSelect {...args} placeholder="medium" size="md" aria-label="select medium" />
+      <KvibSelect {...args} placeholder="large" size="lg" aria-label="select large" />
+    </KvibStack>
+  ),
+};
+
+export const SelectVariants: Story = {
+  args: {},
+  render: (args) => (
+    <KvibStack spacing={3}>
+      <KvibSelect {...args} variant="outline" placeholder="Outline" aria-label="select outline" />
+      <KvibSelect {...args} variant="filled" placeholder="Filled" aria-label="select filled" />
+      <KvibSelect {...args} variant="flushed" placeholder="Flushed" aria-label="select flushed" />
+      <KvibSelect {...args} variant="unstyled" placeholder="Unstyled" aria-label="select unstyled" />
+    </KvibStack>
+  ),
+};
+
+export const SelectIcon: Story = {
+  args: {},
+  render: (args) => (
+    <KvibSelect
+      {...args}
+      icon={<Icon icon="expand_circle_down" weight={300} />}
+      placeholder="Woohoo! Nytt ikon"
+      aria-label="select change Icon"
+    />
+  ),
+};
+
+export const SelectStyles: Story = {
+  args: {},
+  render: (args) => (
+    <KvibSelect
+      {...args}
+      bg="red.500"
+      borderColor="red.500"
+      color="white"
+      placeholder="Ny bakgrunnsfarge!"
+      aria-label="select override style"
+    />
+  ),
+};

--- a/apps/storybook/stories/components/tabs/Tabs.stories.tsx
+++ b/apps/storybook/stories/components/tabs/Tabs.stories.tsx
@@ -51,7 +51,7 @@ export default meta;
 type Story = StoryObj<typeof KvibTabs>;
 
 export const Tabs: Story = {
-  args: { colorScheme: "green", size: "md" },
+  args: { size: "md" },
   render: (args) => (
     <KvibTabs {...args}>
       <KvibTabList>
@@ -83,7 +83,7 @@ export const TabsColors: Story = {
 };
 
 export const TabsNumber: Story = {
-  args: { colorScheme: "green", size: "md" },
+  args: { size: "md" },
   render: (args) => (
     <KvibTabs {...args}>
       <KvibTabList>
@@ -99,7 +99,6 @@ export const TabsNumber: Story = {
 };
 
 export const TabsSizes: Story = {
-  args: { colorScheme: "green" },
   render: (args) => (
     <VStack alignItems="start">
       <KvibTabs {...args} aria-label="Tabs small" size="sm">
@@ -125,7 +124,7 @@ export const TabsSizes: Story = {
 };
 
 export const TabsPanels: Story = {
-  args: { colorScheme: "green", size: "md" },
+  args: { size: "md" },
   render: (args) => (
     <KvibTabs {...args}>
       <KvibTabList>
@@ -141,7 +140,7 @@ export const TabsPanels: Story = {
 };
 
 export const TabsStates: Story = {
-  args: { colorScheme: "green", size: "md" },
+  args: { size: "md" },
   render: (args) => (
     <KvibTabs {...args}>
       <KvibTabList>

--- a/apps/storybook/stories/documentation/bidra/Style.mdx
+++ b/apps/storybook/stories/documentation/bidra/Style.mdx
@@ -26,7 +26,7 @@ IconButton er en komponent hvor useStyleConfig er benyttet, og under vises det h
       defaultProps: {
         variant: "solid",
         size: "md",
-        colorScheme: "green"},
+      },
     });
     ```
 

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -5,7 +5,6 @@ import {
   forwardRef,
   Spinner,
   HStack,
-  useButtonGroup,
 } from "@chakra-ui/react";
 import { Icon } from "../icon";
 
@@ -29,20 +28,9 @@ export type ButtonProps = Omit<
 };
 
 export const Button = forwardRef<ButtonProps, "button">(
-  ({ children, iconFill, colorScheme, isDisabled, isLoading, leftIcon, rightIcon, ...props }, ref) => {
-    const buttonGroup = useButtonGroup();
-    const finalColorScheme = (colorScheme ?? buttonGroup?.colorScheme ?? "green") as Required<
-      ButtonProps["colorScheme"]
-    >;
-
+  ({ children, iconFill, isDisabled, isLoading, leftIcon, rightIcon, ...props }, ref) => {
     return (
-      <ChakraButton
-        {...props}
-        ref={ref}
-        colorScheme={finalColorScheme}
-        isDisabled={isDisabled || isLoading}
-        aria-busy={isLoading}
-      >
+      <ChakraButton {...props} ref={ref} isDisabled={isDisabled || isLoading} aria-busy={isLoading}>
         {isLoading && (
           <Center position="absolute" right="0" left="0">
             <Spinner size="sm" />

--- a/packages/react/src/link/Link.tsx
+++ b/packages/react/src/link/Link.tsx
@@ -11,10 +11,10 @@ export type LinkProps = Omit<ChakraLinkProps, "colorScheme" | "variant"> & {
  *
  * You can specify the `color` prop to get different link designs.
  */
-export const Link = forwardRef<LinkProps, "a">(({ children, colorScheme = "green", ...props }, ref) => {
+export const Link = forwardRef<LinkProps, "a">(({ children, ...props }, ref) => {
   const isExternal = props.isExternal !== undefined ? props.isExternal : Boolean(props.href?.match(/^https?:\/\//));
   return (
-    <ChakraLink {...props} ref={ref} colorScheme={colorScheme} isExternal={isExternal}>
+    <ChakraLink {...props} ref={ref} isExternal={isExternal}>
       {children}
       {isExternal && (
         <span

--- a/packages/react/src/radio/Radio.tsx
+++ b/packages/react/src/radio/Radio.tsx
@@ -4,9 +4,9 @@ export type RadioProps = Exclude<ChakraRadioProps, "colorScheme"> & {
   colorScheme?: "blue" | "green";
 };
 
-export const Radio = forwardRef<RadioProps, "input">(({ children, colorScheme, ...props }, ref) => {
+export const Radio = forwardRef<RadioProps, "input">(({ children, ...props }, ref) => {
   return (
-    <ChakraRadio {...props} ref={ref} colorScheme={colorScheme}>
+    <ChakraRadio {...props} ref={ref}>
       {children}
     </ChakraRadio>
   );

--- a/packages/react/src/tabs/Tabs.tsx
+++ b/packages/react/src/tabs/Tabs.tsx
@@ -2,11 +2,11 @@ import { TabsProps as ChakraTabsProps, Tabs as ChakraTabs, forwardRef } from "@c
 
 export type TabsProps = Omit<ChakraTabsProps, "colorScheme" | "size"> & {
   /**The visual color appearance of the tabs*/
-  colorScheme: "green" | "blue";
+  colorScheme?: "green" | "blue";
   /**The size of the tabs*/
   size: "sm" | "md" | "lg";
 };
 
-export const Tabs = forwardRef<TabsProps, "div">(({ colorScheme = "green", size = "md", ...props }, ref) => {
-  return <ChakraTabs colorScheme={colorScheme} size={size} {...props} ref={ref} />;
+export const Tabs = forwardRef<TabsProps, "div">(({ size = "md", ...props }, ref) => {
+  return <ChakraTabs size={size} {...props} ref={ref} />;
 });

--- a/packages/react/src/theme/components/button.ts
+++ b/packages/react/src/theme/components/button.ts
@@ -279,7 +279,6 @@ export const buttonTheme = defineStyleConfig({
     ghost: variantGhost,
   },
   defaultProps: {
-    colorScheme: "green",
     variant: "solid",
     size: "md",
   },

--- a/packages/react/src/theme/components/iconButton.ts
+++ b/packages/react/src/theme/components/iconButton.ts
@@ -66,6 +66,5 @@ export const IconButtonTheme = defineStyleConfig({
   defaultProps: {
     variant: "solid",
     size: "md",
-    colorScheme: "green",
   },
 });

--- a/packages/react/src/theme/components/iconButton.ts
+++ b/packages/react/src/theme/components/iconButton.ts
@@ -1,7 +1,7 @@
 import { variantSolid, variantOutline, variantLink, variantGhost } from "./button";
 import { defineStyleConfig } from "@chakra-ui/react";
 
-export const IconButtonTheme = defineStyleConfig({
+export const iconButtonTheme = defineStyleConfig({
   baseStyle: () => ({
     borderRadius: "6px",
     outline: 0,
@@ -65,6 +65,7 @@ export const IconButtonTheme = defineStyleConfig({
   },
   defaultProps: {
     variant: "solid",
+    colorScheme: "green",
     size: "md",
   },
 });

--- a/packages/react/src/theme/components/index.ts
+++ b/packages/react/src/theme/components/index.ts
@@ -1,4 +1,4 @@
 export { linkTheme as Link } from "./link";
 export { buttonTheme as Button } from "./button";
 export { tabsTheme as Tabs } from "./tabs";
-export { IconButtonTheme as IconButton } from "./iconButton";
+export { iconButtonTheme as IconButton } from "./iconButton";

--- a/packages/react/src/theme/components/link.ts
+++ b/packages/react/src/theme/components/link.ts
@@ -1,5 +1,5 @@
 import { defineStyleConfig } from "@chakra-ui/react";
-import { colors, borders, radii } from "../tokens";
+import { colors, borders } from "../tokens";
 
 export const linkTheme = defineStyleConfig({
   baseStyle: ({ colorScheme }) => ({
@@ -20,7 +20,4 @@ export const linkTheme = defineStyleConfig({
       textDecoration: "underline",
     },
   }),
-  defaultProps: {
-    colorScheme: "green",
-  },
 });

--- a/packages/react/src/theme/components/tabs.ts
+++ b/packages/react/src/theme/components/tabs.ts
@@ -28,7 +28,6 @@ export const tabsTheme = helpers.defineMultiStyleConfig({
     };
   },
   defaultProps: {
-    colorScheme: "green",
     size: "md",
   },
 });

--- a/packages/react/src/theme/index.ts
+++ b/packages/react/src/theme/index.ts
@@ -1,15 +1,18 @@
-import { extendTheme } from "@chakra-ui/react";
-import { theme as defaultTheme } from "@chakra-ui/theme";
+import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
 import * as components from "./components";
-
 import * as tokens from "./tokens";
 
-export const theme = extendTheme({
-  ...defaultTheme,
-  ...tokens,
+const defaultTheme = extendTheme(
+  withDefaultColorScheme({ colorScheme: "green" }),
+  withDefaultColorScheme({ colorScheme: "gray", components: ["Badge", "Code", "Table", "Tag"] })
+);
 
-  components: {
-    ...defaultTheme.components,
-    ...components,
+export const theme = extendTheme(
+  {
+    ...tokens,
+    components: {
+      ...components,
+    },
   },
-});
+  defaultTheme
+);

--- a/packages/react/src/theme/index.ts
+++ b/packages/react/src/theme/index.ts
@@ -2,17 +2,11 @@ import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
 import * as components from "./components";
 import * as tokens from "./tokens";
 
-const defaultTheme = extendTheme(
-  withDefaultColorScheme({ colorScheme: "green" }),
-  withDefaultColorScheme({ colorScheme: "gray", components: ["Badge", "Code", "Table", "Tag"] })
-);
-
 export const theme = extendTheme(
+  withDefaultColorScheme({ colorScheme: "green" }),
+  withDefaultColorScheme({ colorScheme: "gray", components: ["Badge", "Code", "Table", "Tag"] }),
   {
     ...tokens,
-    components: {
-      ...components,
-    },
-  },
-  defaultTheme
+    components: { ...components },
+  }
 );


### PR DESCRIPTION
Prøvde å oppgradere kvib-versjonen min i nibas forleden, men møtte på en rekke problemer der halve applikasjonen ble grønn, mens den andre havlparten ble blå (altså sånn vi vil ha det i nibas). Nå følger ikke jeg veldig aktivt med på kvib, men det virker som at standardfargen som brukes på komponenter er grønn. Det er noe man kan sette sentralt for alle komponenter, så kan man eventuelt sette komponenter som skal være grå til å være det. Da blir det lettere for konsumenter å sette fargetemaet til sin applikasjon til å være f.eks. blå, fordi komponentene bare arver fargetema fra theme. Konsumenter og komponenter har enda all anledning til å overstyre fargetema, men med denne endringen slipper man å spesifikt si at alt skal være grønt eller blått eller hva nå enn.

Jeg prøvde å oppdatere dokumentasjon til å ikke spesifikt sette `colorScheme="green"` siden det uansett skjer av seg selv nå, slik at man ikke forvirrer brukeren til å tro at de alltid må gjøre det for å få en grønn knapp.

Noen ting å være obs på:

- Siden jeg satte standarden til å være grønn når den før var grå, så kan det godt være noen komponenter som _skulle_ være grå nå er grønn. Jeg tok utgangspunkt i dokumentasjonen for de forskjellige komponentene for å se hva tiltenkt default var. Hvis det er noe som ble feil så er det bare å rette det opp i theme/index, der vi sier hvilke komponenter som skal være grå.
- Jeg la merke til at det er ubrukte stiler i theme/components, de må videre-eksporteres i theme/components/index for å fungere. Det gjelder radio.ts og input.ts fra det jeg kan se.
- Prøv å unngå å tukle med colorscheme på komponentnivå med mindre man skal gjøre noe spesielt med det, det er veldig mye som allerede skjer av seg selv. F.eks. i Button.tsx ser jeg at dere har prøvd å få knapper til å arve fra buttongroup, men de gjør allerede det av seg selv, så annet enn typen trenger man ikke å nevne colorscheme.