### PR TITLE
Legger til manglende className på Icon

### DIFF
--- a/.changeset/tidy-cheetahs-begin.md
+++ b/.changeset/tidy-cheetahs-begin.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Legger til manglende className på Icon

--- a/packages/react/src/icon/Icon.tsx
+++ b/packages/react/src/icon/Icon.tsx
@@ -5,6 +5,7 @@ export const Icon = ({
   weight,
   grade,
   isFilled = false,
+  className = "",
 }: {
   /**The icon from Material symbols you want to display*/
   icon: string;
@@ -23,10 +24,12 @@ export const Icon = ({
 
   /**Decides whether the icon is filled or not*/
   isFilled?: boolean;
+
+  className?: string;
 }) => {
   return (
     <span
-      className="material-symbols-rounded"
+      className={`material-symbols-rounded ${className}`}
       style={{
         fontSize: size,
         color: color,


### PR DESCRIPTION
For å kunne style komponenter fra kvib via andre rammeverk som styled-components så må komponentene kunne ta imot className, det manglet på Icon. Når vi utvider komponenter fra Chakra så går det greit fordi vi som regel bruker en modifikasjon av chakra sine props typer, som inkluderer className. 

En bedre versjon av denne endringen ville vært å gjøre at Icon egentlig bare tar imot hva nå enn en span normalt kan ta imot, slik at man ikke blir begrenset av komponenter hvis man f.eks. vil sette en aria sak, men hadde ikke tid til å fikse det akkurat nå, dette er en forbedring uansett.