### PR TITLE
Øker størrelse på ikoner for IconButton

### DIFF
--- a/.changeset/hungry-apes-run.md
+++ b/.changeset/hungry-apes-run.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Øker størrelse på ikoner for IconButton

--- a/packages/react/src/theme/components/iconButton.ts
+++ b/packages/react/src/theme/components/iconButton.ts
@@ -25,7 +25,7 @@ export const iconButtonTheme = defineStyleConfig({
       width: "24px",
       height: "24px",
       ".material-symbols-rounded": {
-        fontSize: "12px",
+        fontSize: "20px",
       },
     },
     sm: {
@@ -34,7 +34,7 @@ export const iconButtonTheme = defineStyleConfig({
       width: "32px",
       height: "32px",
       ".material-symbols-rounded": {
-        fontSize: "14px",
+        fontSize: "20px",
       },
     },
     md: {
@@ -43,7 +43,7 @@ export const iconButtonTheme = defineStyleConfig({
       width: "40px",
       height: "40px",
       ".material-symbols-rounded": {
-        fontSize: "16px",
+        fontSize: "24px",
       },
     },
     lg: {
@@ -53,7 +53,7 @@ export const iconButtonTheme = defineStyleConfig({
       width: "48px",
       height: "48px",
       ".material-symbols-rounded": {
-        fontSize: "18px",
+        fontSize: "24px",
       },
     },
   },


### PR DESCRIPTION
Ref https://github.com/kartverket/kvib/pull/410 så innser jeg at vi kanskje bør øke størrelsen på ikonene for IconButton også, ikonene ble veldig små i Nibas i hvertfall. 
Tok utgangspunkt i de samme størrelsene til Button, men ser at knappen ellers er skrevet litt annerledes. Testet ut om jeg på en god måte kunne bare bruke button sine styles og overskrive dem ved behov, men møtte på snodige bugs, så jeg droppet det.