### PR TITLE
Litt pimping på designet på storybook

### DIFF
--- a/apps/storybook/.storybook/manager-head.html
+++ b/apps/storybook/.storybook/manager-head.html
@@ -1,2 +1,3 @@
 <link rel="shortcut icon" href="/favicon.ico" />
 <link rel="icon" type="image/png" href="/favicon.png" sizes="192x192" />
+<link href="https://fonts.googleapis.com/css?family=Mulish:300,400,500,600,700" rel="stylesheet" />

--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -1,4 +1,5 @@
 import { KvibProvider } from "@kvib/react/src/provider/KvibProvider";
+import theme from "./theme";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -7,6 +8,9 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+  },
+  docs: {
+    theme: theme,
   },
   options: {
     storySort: {

--- a/apps/storybook/.storybook/theme.js
+++ b/apps/storybook/.storybook/theme.js
@@ -3,8 +3,30 @@ import logo from "./kvib_logo.svg";
 
 export default create({
   base: "light",
+  // Typography
+  fontBase: '"Mulish", "Open Sans", sans-serif',
+  fontCode: "monospace",
   brandTitle: "KVIB",
   brandUrl: "https://kartverket.github.io/kvib/storybook",
   brandImage: logo,
   brandTarget: "_self",
+
+  //
+  colorPrimary: "#1A589F",
+  colorSecondary: "#1A589F",
+
+  // UI
+  appBg: "#F5F2F2",
+  appContentBg: "#ffffff",
+  appBorderColor: "#E3E0E0",
+  appBorderRadius: 16,
+
+  // Text colors
+  textColor: "#202020",
+  textInverseColor: "#ffffff",
+
+  // Toolbar default and active colors
+  barTextColor: "#1A589F",
+  barSelectedColor: "#1A589F",
+  barBg: "#E4F1F8",
 });


### PR DESCRIPTION
# Beskrivelse

Endret litt på designet på storybook for å ta i bruk Kartverket sine farger og fonter der det var mulig. Spesifikt vår blåfarge, og lys blå på toolbar og addons + lys grå på sidebaren. Bruker også Mulish i stedet for Open Sans.

Før:
<img width="1269" alt="Skjermbilde 2023-08-18 kl  16 24 08" src="https://github.com/kartverket/kvib/assets/112624037/cdb2524a-7db0-44f2-91d0-5d31282d8f62">

Etter:
<img width="1264" alt="Skjermbilde 2023-08-18 kl  16 24 25" src="https://github.com/kartverket/kvib/assets/112624037/e5dd4dad-31a6-4a12-a5a7-48fd1bbca018">

