### PR TITLE
Fjern forwardRef for PinInput som ikke tar imot ref

### DIFF
--- a/.changeset/wise-crews-explode.md
+++ b/.changeset/wise-crews-explode.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Fjern forwardRef for PinInput som ikke tar imot ref

--- a/packages/react/src/pin-input/Pin-Input.tsx
+++ b/packages/react/src/pin-input/Pin-Input.tsx
@@ -1,9 +1,9 @@
-import { PinInput as ChakraPinInput, PinInputProps as ChakraPinInputProps, forwardRef } from "@chakra-ui/react";
+import { PinInput as ChakraPinInput, PinInputProps as ChakraPinInputProps } from "@chakra-ui/react";
 
-export const PinInput = forwardRef<ChakraPinInputProps, "div">(({ size, children, ...props }) => {
+export const PinInput = ({ size, children, ...props }: ChakraPinInputProps) => {
   return (
     <ChakraPinInput {...props} size={size}>
       {children}
     </ChakraPinInput>
   );
-});
+};


### PR DESCRIPTION
# Beskrivelse

Alle konsumenter av kvib får følgende feilmelding:

![image](https://github.com/kartverket/kvib/assets/14059677/5ed834f5-7c79-4b15-8493-70fe57ac97fe)

Det kommer av at vi bruker forwardRef å PinInput uten å bruke ref. Vi kan heller ikke bruke ref, ettersom PinInput fra Chakra ikke tar imot ref. Da er det ikke noe vits at vår PinInput tar imot ref heller, så da kan man fjerne forwardRef fra vår komponent slik at ikke alle konsumenter får feilmelding i konsollen sin uten noen peiling på hvor det kommer fra