### PR TITLE
KOMP-242-previewUrl

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,3 @@
-# .github/workflows/preview.yml
 name: Deploy PR previews
 
 on:
@@ -26,4 +25,4 @@ jobs:
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./build/
+          source-dir: ./apps/storybook/storybook-static

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,4 +32,3 @@ jobs:
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./apps/storybook/storybook-static
-          umbrella-dir: storybook/pr-preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,29 @@
+# .github/workflows/preview.yml
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install and Build
+        run: |
+          npm install --frozen-lockfile
+          npm run build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./build/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "npm"
+
       - name: Install and Build
         run: |
           npm install --frozen-lockfile
@@ -25,4 +31,4 @@ jobs:
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./build/
+          source-dir: ./apps/storybook/storybook-static

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,9 +27,9 @@ jobs:
         run: |
           npm install --frozen-lockfile
           npm run build
-          ls ./apps/storybook/storybook-static
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./apps/storybook/storybook-static
+          umbrella-dir: storybook/pr-preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./apps/storybook/storybook-static
+          source-dir: ./build/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           npm install --frozen-lockfile
           npm run build
+          ls ./apps/storybook/storybook-static
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/apps/storybook/.storybook/theme.js
+++ b/apps/storybook/.storybook/theme.js
@@ -1,13 +1,15 @@
 import { create } from "@storybook/theming";
 import logo from "./kvib_logo.svg";
 
+const isLocalhost = window.location.hostname === "localhost";
+
 export default create({
   base: "light",
   // Typography
   fontBase: '"Mulish", "Open Sans", sans-serif',
   fontCode: "monospace",
   brandTitle: "KVIB",
-  brandUrl: "/",
+  brandUrl: isLocalhost ? "/" : "/kvib",
   brandImage: logo,
   brandTarget: "_self",
 

--- a/apps/storybook/index.html
+++ b/apps/storybook/index.html
@@ -2,4 +2,4 @@
 <meta charset="utf-8" />
 <title>KVIB</title>
 <link rel="icon" href=".storybook/kvib_logo.svg" />
-<link rel="canonical" href="https://kartverket.github.io/kvib/storybook" />
+<link rel="canonical" href="https://kartverket.github.io/kvib/" />

--- a/apps/storybook/index.html
+++ b/apps/storybook/index.html
@@ -3,3 +3,4 @@
 <title>KVIB</title>
 <link rel="icon" href=".storybook/kvib_logo.svg" />
 <link rel="canonical" href="https://kartverket.github.io/kvib/storybook" />
+<body></body>

--- a/apps/storybook/index.html
+++ b/apps/storybook/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
 <title>Redirect to kvib/storybook</title>
-<meta http-equiv="refresh" content="0; https://kartverket.github.io/kvib/storybook" />
 <link rel="icon" href=".storybook/kvib_logo.svg" />
-<link rel="canonical" href="https://kartverket.github.io/kvib/storybook" />
+<link rel="canonical" href="https://kartverket.github.io/kvib" />

--- a/apps/storybook/index.html
+++ b/apps/storybook/index.html
@@ -3,4 +3,3 @@
 <title>KVIB</title>
 <link rel="icon" href=".storybook/kvib_logo.svg" />
 <link rel="canonical" href="https://kartverket.github.io/kvib/storybook" />
-<body></body>

--- a/apps/storybook/index.html
+++ b/apps/storybook/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8" />
-<title>Redirect to kvib/storybook</title>
+<title>KVIB</title>
 <link rel="icon" href=".storybook/kvib_logo.svg" />
-<link rel="canonical" href="https://kartverket.github.io/kvib" />
+<link rel="canonical" href="https://kartverket.github.io/kvib/storybook" />

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -8,7 +8,6 @@
     "dev": "storybook dev -p 6006",
     "build": "storybook build",
     "build-storybook": "storybook build",
-    "postbuild": "mv storybook-static/index.html storybook-static/storybook.html && cp index.html storybook-static/index.html",
     "test-storybook": "test-storybook"
   },
   "keywords": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/storybook": {
       "name": "@kvib/storybook",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@storybook/addon-a11y": "^7.0.23"
@@ -28106,7 +28106,7 @@
     },
     "packages/react": {
       "name": "@kvib/react",
-      "version": "1.23.0",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.5.1",


### PR DESCRIPTION
Legger til github actions for preview url på github pages.

(Av en eller annen grunn så vil urlen til KVIB alltid endre seg til /kvib/storybook - noe som det virker som lager krøll for previews. Må undersøkes nærmere.) - Tror jeg fant svaret på dette: 

- Index.html i storybook redirected til /kvib/storybook, i tillegg til at det fantes et postbuild step i package.json. Dette ser ut som rester som ble brukt rundt tiden man flyttet/brukte old-kvib. Jeg fjernet postbuild og redirect, noe som forhåpentligvis vil fikse alle url-problemene vi har hatt. 

**Sjekk ut den første preview-urlen under**😎
