### PR TITLE
NRL ønsker direkte kontakt fra footer

### DIFF
--- a/apps/storybook/stories/components/footer/Footer.stories.tsx
+++ b/apps/storybook/stories/components/footer/Footer.stories.tsx
@@ -55,6 +55,9 @@ const meta: Meta<typeof KvibFooter> = {
       },
       control: "boolean",
     },
+    contactInfoEmailAddress: {
+      control: "text",
+    },
   },
 };
 

--- a/packages/react/src/footer/Footer.tsx
+++ b/packages/react/src/footer/Footer.tsx
@@ -54,7 +54,11 @@ export const Footer = ({
                 </Text>
                 <Text>
                   E-post:{" "}
-                  <Link fontWeight="bold" aria-label="Send e-post til Kartverket" href="mailto:post@kartverket.no">
+                  <Link
+                    fontWeight="bold"
+                    aria-label="Send e-post til Kartverket"
+                    href={"mailto:" + contactInfoEmailAddress}
+                  >
                     {" "}
                     {contactInfoEmailAddress}{" "}
                   </Link>

--- a/packages/react/src/footer/Footer.tsx
+++ b/packages/react/src/footer/Footer.tsx
@@ -7,6 +7,7 @@ export type FooterProps = {
   excludeContactInfo?: boolean;
   excludeHelp?: boolean;
   excludeNews?: boolean;
+  contactInfoEmailAddress?: string
 };
 
 const FooterToggleableFlex = (props: FlexProps) => {
@@ -26,6 +27,7 @@ export const Footer = ({
   excludeHelp,
   excludeNews,
   excludeSocialMedia,
+  contactInfoEmailAddress,
 }: FooterProps) => {
   const onlyOneIncluded =
     (!excludeContactInfo || !excludeOpeningHours ? 1 : 0) + (!excludeHelp ? 1 : 0) + (!excludeNews ? 1 : 0) <= 1;
@@ -52,7 +54,7 @@ export const Footer = ({
                   E-post:{" "}
                   <Link fontWeight="bold" aria-label="Send e-post til Kartverket" href="mailto:post@kartverket.no">
                     {" "}
-                    post@kartverket.no{" "}
+                    {contactInfoEmailAddress || "post@kartverket.no"}{" "}
                   </Link>
                 </Text>
                 <Link

--- a/packages/react/src/footer/Footer.tsx
+++ b/packages/react/src/footer/Footer.tsx
@@ -7,7 +7,9 @@ export type FooterProps = {
   excludeContactInfo?: boolean;
   excludeHelp?: boolean;
   excludeNews?: boolean;
-  contactInfoEmailAddress?: string
+  /**The contact info email-adress
+   * @default post@kartverket.no*/
+  contactInfoEmailAddress?: string;
 };
 
 const FooterToggleableFlex = (props: FlexProps) => {
@@ -27,7 +29,7 @@ export const Footer = ({
   excludeHelp,
   excludeNews,
   excludeSocialMedia,
-  contactInfoEmailAddress,
+  contactInfoEmailAddress = "post@kartverket.no",
 }: FooterProps) => {
   const onlyOneIncluded =
     (!excludeContactInfo || !excludeOpeningHours ? 1 : 0) + (!excludeHelp ? 1 : 0) + (!excludeNews ? 1 : 0) <= 1;
@@ -54,7 +56,7 @@ export const Footer = ({
                   E-post:{" "}
                   <Link fontWeight="bold" aria-label="Send e-post til Kartverket" href="mailto:post@kartverket.no">
                     {" "}
-                    {contactInfoEmailAddress || "post@kartverket.no"}{" "}
+                    {contactInfoEmailAddress}{" "}
                   </Link>
                 </Text>
                 <Link


### PR DESCRIPTION
# Beskrivelse
Jeg tipper at NRL kan hoppe over til å bruke kvib sin footer, men jeg vet at det har vært ønskelig at NRL kan kontaktes direkte fra footer. (ref. nrl@kartverket.no i den nederste footeren på bildet)

Legger til et skjermbilde av kvib footer vs NRL footer.
Vi har også Postadresse pluss en "tilbake til NRL" knapp. Kan dobbelt sjekke, men jeg tror ikke dette er viktig.
EDIT: Postadresse ligger inne i "[Kontaktinfo og adresser launch](https://kartverket.no/om-kartverket/kontakt-oss)" lenken deres så det må jo være ok 

<img width="1372" alt="Screenshot 2023-08-31 at 1 53 37 PM" src="https://github.com/kartverket/kvib/assets/15320199/3832505a-7aed-4e6b-b134-b0a46b047b8f">
