### PR TITLE
KOMP-249-removeIsSelected

### DIFF
--- a/apps/storybook/stories/components/tabs/Tabs.mdx
+++ b/apps/storybook/stories/components/tabs/Tabs.mdx
@@ -8,8 +8,6 @@ import * as TabsStories from "./Tabs.stories";
 Tabs brukes til å veksle mellom paneler på en side. Dette hjelper brukere med å navigere mellom relatert innhold uten bytte kontekst. Komponenten består av en rad med tab-knapper. En tab-knapp er alltid valgt, fordi et panel alltid vises.
 Du kan ha alle typer elementer i `Tabs`, men `TabList`skal bare ha `Tab` som children.
 
-Se [https://chakra-ui.com/docs/components/tabs](https://chakra-ui.com/docs/components/tabs) dersom du trenger props utover det som er sett som nødvendig i KVIB.
-
 ## Ta i bruk
 
 ```jsx

--- a/apps/storybook/stories/components/tabs/Tabs.stories.tsx
+++ b/apps/storybook/stories/components/tabs/Tabs.stories.tsx
@@ -144,7 +144,7 @@ export const TabsStates: Story = {
   render: (args) => (
     <KvibTabs {...args}>
       <KvibTabList>
-        <KvibTab isSelected>Selected</KvibTab>
+        <KvibTab>Enabled</KvibTab>
         <KvibTab isDisabled>Disabled</KvibTab>
       </KvibTabList>
     </KvibTabs>


### PR DESCRIPTION
Fjerner isSelected fra dokumentasjonen til tabs.

isSelected eksisterer i dokumentasjonen til chakra, men er ikke en prop i tab.