### PR TITLE
KOMP-261-dependabotPreview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,7 @@
 name: Deploy PR previews
 
 on:
+  workflow dispatch:
   pull_request:
     types:
       - opened

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 name: Deploy PR previews
 
 on:
-  workflow dispatch:
+  workflow_dispatch:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Legger til workflow dispatch for pr-preview.

Dette gjøres fordi dependabot ikke kan lage pr-previews for bumps fordi dependabot er sett på som "untrusted" av github.