### PR TITLE
Lagt til changelog

### DIFF
--- a/.changeset/proud-snakes-lay.md
+++ b/.changeset/proud-snakes-lay.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Bumped @fontsource/mulish from 4.5.14 to 5.0.8


### PR DESCRIPTION
Dependabot oppdaterer ikke automatisk changelog når den gjør endringer. Dette må vi få inn en rutine på å gjøre selv når vi godkjenner PRs fra dependabot som gjør endringer i react-pakka. Det glemte jeg i denne omgang, så denne pull-requesten gjelder changelog for den ene oppdateringen som påvirket react-pakka av de jeg har godkjent i denne omgang.