### PR TITLE
KOMP-295-icons

### DIFF
--- a/.changeset/chatty-phones-join.md
+++ b/.changeset/chatty-phones-join.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Legger til en manglende import som skal løse alle problemer med ikoner i noen prosjekter.

--- a/packages/react/src/icon/Icon.tsx
+++ b/packages/react/src/icon/Icon.tsx
@@ -1,4 +1,5 @@
 import { MaterialSymbol } from "material-symbols";
+import "material-symbols";
 
 export const Icon = ({
   icon,


### PR DESCRIPTION
Ikoner har ikke fungert i noen prosjekter. Dette burde være det som manglet.
Legger til material-symbols import.