### PR TITLE
KOMP-304-dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,21 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      patch-minor-dependencies:
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      major-dependencies:
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
# Beskrivelse

Legger til grupper basert på semver version. Det vil si at dependabot vil gruppere package-bumps i en pr for patch og minor, og en for major (forhåpentligvis). Da blir det raskere å oppdatere og det blir lettere å følge med på hva som lager breaking changes. 

Jeg skal se om det er mulig å få dependabot til å lage changesets.
