### PR TITLE
KOMP-298: Ny token i workflow (slack)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Generate an app token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app_id: ${{ secrets.WORKFLOW_MANAGER_ID }}
+          private_key: ${{ secrets.WORKFLOW_MANAGER_PRIVATE_KEY }}
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -34,5 +41,5 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run publish-packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION

# Beskrivelse

**Endring:**

Endrer fra å bruke generisk github token til app token for å trigge flere workflows. 

**Hvorfor:**

For å sende updates til slack, må en ny workflow bli kjørt på github event `released`.

For at det skal være mulig å trigge en ny workflow på github event `released`, så kan ikke den forrige workflowen bli kjørt gjennom en github-token. En vanlig github-token har bare mulighet til å trigge sin egen workflow. Derfor må man enten bruke sin egen token, eller en app-token. Jeg valgte app-token slik at det er lett å bytte den ut/ gi andre eierskap - i tillegg til at det er lett å gi den riktige permissions. 

**Liten warning:** Usikker på om appen har fått nok permissions for å release - det må vi se på release. 

