### PR TITLE
komp-337-logo

### DIFF
--- a/apps/storybook/.storybook/theme.js
+++ b/apps/storybook/.storybook/theme.js
@@ -10,7 +10,7 @@ export default create({
   fontBase: '"Mulish Variable", "Open Sans", sans-serif',
   fontCode: "monospace",
   brandTitle: "Kartverkets Designsystem",
-  brandUrl: isLocalhost ? "/" : "/kvib",
+  brandUrl: "/",
   brandImage: logo,
   brandTarget: "_self",
 

--- a/apps/storybook/.storybook/theme.js
+++ b/apps/storybook/.storybook/theme.js
@@ -2,8 +2,6 @@ import { create } from "@storybook/theming";
 import logo from "./kvib_logo.svg";
 import "@fontsource-variable/mulish";
 
-const isLocalhost = window.location.hostname === "localhost";
-
 export default create({
   base: "light",
   // Typography


### PR DESCRIPTION
Endrer brandUrl til å passe nytt domene.

/Kvib finnes ikke lenger - nå er det "/". 

design.kartverket.no