### PR TITLE
Komp-364-searchButtonText

### DIFF
--- a/.changeset/modern-zoos-share.md
+++ b/.changeset/modern-zoos-share.md
@@ -1,0 +1,10 @@
+---
+"@kvib/react": major
+---
+
+Legger til støtte for å legge til tekst på søkeknappen i Search. Bruk `buttonText`.
+
+Breaking changes:
+
+- Fjerner `leftSearchButton` og `rightSearchButton` til fordel for å legge til ny prop.
+- Legger til ny prop `searchButton?: "left" | "right" | "none";`

--- a/apps/storybook/stories/components/search/search/Search.mdx
+++ b/apps/storybook/stories/components/search/search/Search.mdx
@@ -56,16 +56,18 @@ import { Search } from "@kvib/react";
 />
 
 <DocsStory
-  title="Søkeknapp/ikon"
+  title="Søkeknapp"
   description={
     <Box>
       <Text>
-        Search har muligheten til å legge inn knapp med søkeikon ved å benytte enten <Code>leftSearchIcon</Code> eller
-        <Code>rightSearchIcon</Code>. Disse har <Code>type="submit"</Code> som gjør at de passer inn i et form.
+        Search har muligheten til å legge inn knapp med søkeikon ved å benytte <Code>searchButton</Code>-proppen med
+        verdiene <Code>"left"</Code> eller <Code>"right"</Code> - standard er <Code>"none"</Code>. Disse har{" "}
+        <Code>type="submit"</Code> som gjør at de passer inn i et form. Det er også mulig å legge til tekst på knappen
+        ved bruk av <Code>buttonText</Code>.
       </Text>
       <Text>
         Søkeknappen kan tilpasses ved å legge verdier til <Code>buttonVariant</Code> og <Code>buttonWidth</Code>.
-        Knappen er en <Code>IconButton</Code> og har tilsvarende varianter.
+        Knappen er en <Code>IconButton</Code>/<Code>Button</Code> og har tilsvarende varianter.
       </Text>
     </Box>
   }
@@ -93,5 +95,11 @@ Det gjøres enten med en av ikonknappene i props, eller egen knapp.
 </DocsContainer>
 
 <DocsHeading>Props</DocsHeading>
+
+<Alert status="info">
+  <AlertIcon />
+  Padding på søkeinput regnes ut ved rerender noe som gjør at endring av props på dokumentasjonssiden kan gjøre at søkefeltet
+  ser rart ut. Bytt mellom stories for å se en rerender.
+</Alert>
 <Canvas of={SearchStories.Search} />
 <Controls of={SearchStories.Search} />

--- a/apps/storybook/stories/components/search/search/Search.mdx
+++ b/apps/storybook/stories/components/search/search/Search.mdx
@@ -69,15 +69,7 @@ import { Search } from "@kvib/react";
       </Text>
     </Box>
   }
-  story={
-    <Canvas>
-      <Stack gap="1rem">
-        <Story of={SearchStories.SearchIconRight} />
-        <Story of={SearchStories.SearchIconLeft} />
-        <Story of={SearchStories.SearchButtonVariant} />
-      </Stack>
-    </Canvas>
-  }
+  story={<Canvas of={SearchStories.SearchButtonAppearance} />}
 />
 
 </DocsContainer>

--- a/apps/storybook/stories/components/search/search/Search.stories.tsx
+++ b/apps/storybook/stories/components/search/search/Search.stories.tsx
@@ -90,13 +90,22 @@ const meta: Meta<typeof KvibSearch> = {
       control: { type: "radio" },
     },
     buttonWidth: {
-      description: "Button width if an icon is enabled",
+      description:
+        "Button width if an icon is enabled. Cannot be smaller than default, e.g. needs to be more than 2.5rem with size md",
+      table: {
+        type: { summary: "string" },
+      },
+      control: "text",
+    },
+    buttonText: {
+      description: "Button text if an icon is enabled",
       table: {
         type: { summary: "string" },
       },
       control: "text",
     },
   },
+  args: {},
 };
 
 export default meta;
@@ -168,4 +177,32 @@ export const SearchButtonVariant: SearchStory = {
     buttonWidth: "4rem",
   },
   render: (args) => <KvibSearch {...args} />,
+};
+
+export const SearchButtonText: SearchStory = {
+  args: {
+    rightSearchIcon: true,
+    placeholder: "Søk her...",
+    variant: "outline",
+    isDisabled: false,
+    colorScheme: "blue",
+    buttonVariant: "primary",
+    buttonText: "Søk",
+  },
+  render: (args) => <KvibSearch {...args} />,
+};
+
+export const SearchButtonAppearance: SearchStory = {
+  args: {
+    placeholder: "Søk her...",
+    variant: "outline",
+  },
+  render: (args) => (
+    <Stack>
+      <KvibSearch {...args} rightSearchIcon={true} colorScheme="green" />
+      <KvibSearch {...args} leftSearchIcon={true} colorScheme="blue" buttonVariant="secondary" buttonText="Search" />
+      <KvibSearch {...args} rightSearchIcon={true} colorScheme="green" buttonWidth="4rem" buttonVariant="primary" />
+      <KvibSearch {...args} rightSearchIcon={true} colorScheme="blue" buttonVariant="primary" buttonText="Søk" />
+    </Stack>
+  ),
 };

--- a/apps/storybook/stories/components/search/search/Search.stories.tsx
+++ b/apps/storybook/stories/components/search/search/Search.stories.tsx
@@ -181,7 +181,7 @@ export const SearchButtonVariant: SearchStory = {
 
 export const SearchButtonText: SearchStory = {
   args: {
-    rightSearchIcon: true,
+    leftSearchIcon: true,
     placeholder: "Søk her...",
     variant: "outline",
     isDisabled: false,

--- a/apps/storybook/stories/components/search/search/Search.stories.tsx
+++ b/apps/storybook/stories/components/search/search/Search.stories.tsx
@@ -40,21 +40,14 @@ const meta: Meta<typeof KvibSearch> = {
       options: ["outline", "filled", "flushed", "unstyled"],
       control: { type: "radio" },
     },
-    leftSearchIcon: {
-      description: "Enables Search IconButton",
+
+    searchButton: {
+      description: "Add search button to input",
       table: {
-        type: { summary: "boolean" },
-        defaultValue: { summary: false },
+        defaultValue: { summary: "none" },
       },
-      control: "boolean",
-    },
-    rightSearchIcon: {
-      description: "Enables Search IconButton",
-      table: {
-        type: { summary: "boolean" },
-        defaultValue: { summary: false },
-      },
-      control: "boolean",
+      options: ["none", "left", "right"],
+      control: { type: "radio" },
     },
     colorScheme: {
       description: "Change Icon color",
@@ -145,7 +138,7 @@ export const SearchVariants: SearchStory = {
 
 export const SearchIconLeft: SearchStory = {
   args: {
-    leftSearchIcon: true,
+    searchButton: "left",
     placeholder: "Søk her...",
     variant: "outline",
     isDisabled: false,
@@ -157,7 +150,7 @@ export const SearchIconLeft: SearchStory = {
 
 export const SearchIconRight: SearchStory = {
   args: {
-    rightSearchIcon: true,
+    searchButton: "right",
     placeholder: "Søk her...",
     variant: "outline",
     isDisabled: false,
@@ -168,7 +161,7 @@ export const SearchIconRight: SearchStory = {
 
 export const SearchButtonVariant: SearchStory = {
   args: {
-    rightSearchIcon: true,
+    searchButton: "right",
     placeholder: "Søk her...",
     variant: "outline",
     isDisabled: false,
@@ -181,7 +174,7 @@ export const SearchButtonVariant: SearchStory = {
 
 export const SearchButtonText: SearchStory = {
   args: {
-    leftSearchIcon: true,
+    searchButton: "right",
     placeholder: "Søk her...",
     variant: "outline",
     isDisabled: false,
@@ -199,10 +192,10 @@ export const SearchButtonAppearance: SearchStory = {
   },
   render: (args) => (
     <Stack>
-      <KvibSearch {...args} rightSearchIcon={true} colorScheme="green" />
-      <KvibSearch {...args} leftSearchIcon={true} colorScheme="blue" buttonVariant="secondary" buttonText="Search" />
-      <KvibSearch {...args} rightSearchIcon={true} colorScheme="green" buttonWidth="4rem" buttonVariant="primary" />
-      <KvibSearch {...args} rightSearchIcon={true} colorScheme="blue" buttonVariant="primary" buttonText="Søk" />
+      <KvibSearch {...args} searchButton="right" colorScheme="green" />
+      <KvibSearch {...args} searchButton="left" colorScheme="blue" buttonVariant="secondary" />
+      <KvibSearch {...args} searchButton="right" colorScheme="green" buttonWidth="4rem" buttonVariant="primary" />
+      <KvibSearch {...args} searchButton="right" colorScheme="blue" buttonVariant="primary" buttonText="Søk" />
     </Stack>
   ),
 };

--- a/packages/react/src/icon/Icon.tsx
+++ b/packages/react/src/icon/Icon.tsx
@@ -31,6 +31,7 @@ export const Icon = forwardRef<IconProps, "span">(
         ref={ref}
         className={`material-symbols-rounded ${className}`}
         style={{
+          width: size,
           fontSize: size,
           color: color,
           fontVariationSettings: `'FILL' ${isFilled ? 1 : 0}, 'wght' ${weight ? weight : 300}, 'GRAD' ${

--- a/packages/react/src/search/Search.tsx
+++ b/packages/react/src/search/Search.tsx
@@ -5,7 +5,6 @@ import {
   InputGroup as ChakraInputGroup,
   InputLeftElement as ChakraInputLeftElement,
   InputRightElement as ChakraInputRightElement,
-  Box,
   useDimensions,
 } from "@chakra-ui/react";
 import { IconButton, Button } from "../button";
@@ -79,10 +78,13 @@ export const Search = forwardRef<SearchProps, "input">(
         ? `calc(${dimensions.borderBox.width}px + 0.5rem)`
         : "3rem";
 
+    console.log("inputPadding", inputPadding);
+    console.log("dimensions", dimensions?.borderBox.width);
+
     const paddingProp = (position: "left" | "right") => (position === "left" ? "paddingLeft" : "paddingRight");
 
     const RenderInputGroup = ({ position }: RenderProps) => (
-      <Box as={ChakraInputGroup} size={size} gap={"4rem"}>
+      <ChakraInputGroup size={size} width={props.width}>
         <ChakraInput
           {...props}
           id={id}
@@ -94,16 +96,16 @@ export const Search = forwardRef<SearchProps, "input">(
           {...{ [paddingProp(position)]: inputPadding }}
         />
         {position === "left" && (
-          <ChakraInputLeftElement width={buttonWidth}>
+          <ChakraInputLeftElement width="auto">
             <RenderButton position={"left"} />
           </ChakraInputLeftElement>
         )}
         {position === "right" && (
-          <ChakraInputRightElement width={buttonWidth}>
+          <ChakraInputRightElement width="auto">
             <RenderButton position={"right"} />
           </ChakraInputRightElement>
         )}
-      </Box>
+      </ChakraInputGroup>
     );
 
     return (

--- a/packages/react/src/search/Search.tsx
+++ b/packages/react/src/search/Search.tsx
@@ -76,9 +76,7 @@ export const Search = forwardRef<SearchProps, "input">(
         ? `calc(${dimensions.borderBox.width}px + 0.5rem)`
         : "3rem";
 
-    const paddingProp = (position: "left" | "right") => (position === "left" ? "paddingLeft" : "paddingRight");
-
-    const RenderInputGroup = ({ position }: RenderProps) => (
+    const RenderInputGroup = () => (
       <ChakraInputGroup size={size} width={props.width}>
         <ChakraInput
           {...props}
@@ -88,14 +86,15 @@ export const Search = forwardRef<SearchProps, "input">(
           type={type}
           variant={variant}
           isDisabled={isDisabled}
-          {...{ [paddingProp(position)]: inputPadding }}
+          paddingLeft={searchButton === "left" ? inputPadding : undefined}
+          paddingRight={searchButton === "right" ? inputPadding : undefined}
         />
-        {position === "left" && (
+        {searchButton === "left" && (
           <ChakraInputLeftElement width="auto">
             <RenderButton position={"left"} />
           </ChakraInputLeftElement>
         )}
-        {position === "right" && (
+        {searchButton === "right" && (
           <ChakraInputRightElement width="auto">
             <RenderButton position={"right"} />
           </ChakraInputRightElement>
@@ -103,14 +102,6 @@ export const Search = forwardRef<SearchProps, "input">(
       </ChakraInputGroup>
     );
 
-    return (
-      <>
-        {searchButton === "left" && <RenderInputGroup position="left" />}
-        {searchButton === "right" && <RenderInputGroup position="right" />}
-        {searchButton === "none" && (
-          <ChakraInput {...props} id={id} ref={ref} size={size} type={type} variant={variant} isDisabled={isDisabled} />
-        )}
-      </>
-    );
+    return <RenderInputGroup />;
   },
 );

--- a/packages/react/src/search/Search.tsx
+++ b/packages/react/src/search/Search.tsx
@@ -11,8 +11,7 @@ import { IconButton, Button } from "../button";
 import { useRef } from "react";
 
 export type SearchProps = Omit<ChakraInputProps, "isRequired" | "colorScheme"> & {
-  leftSearchIcon?: boolean;
-  rightSearchIcon?: boolean;
+  searchButton?: "left" | "right" | "none";
   colorScheme?: "gray" | "red" | "green" | "blue" | undefined;
   buttonVariant?: "primary" | "secondary" | "tertiary" | "ghost";
   buttonWidth?: string;
@@ -32,8 +31,7 @@ export const Search = forwardRef<SearchProps, "input">(
       variant,
       type = "search",
       isDisabled,
-      leftSearchIcon,
-      rightSearchIcon,
+      searchButton = "none",
       buttonWidth,
       buttonVariant = "tertiary",
       buttonText,
@@ -63,7 +61,7 @@ export const Search = forwardRef<SearchProps, "input">(
       };
 
       return buttonText ? (
-        <Button ref={elementRef} {...buttonProps} rightIcon="search">
+        <Button ref={elementRef} {...buttonProps} rightIcon="search" type="submit" aria-label="search">
           {buttonText}
         </Button>
       ) : (
@@ -110,9 +108,9 @@ export const Search = forwardRef<SearchProps, "input">(
 
     return (
       <>
-        {leftSearchIcon && <RenderInputGroup position="left" />}
-        {rightSearchIcon && <RenderInputGroup position="right" />}
-        {!leftSearchIcon && !rightSearchIcon && (
+        {searchButton === "left" && <RenderInputGroup position="left" />}
+        {searchButton === "right" && <RenderInputGroup position="right" />}
+        {searchButton === "none" && (
           <ChakraInput {...props} id={id} ref={ref} size={size} type={type} variant={variant} isDisabled={isDisabled} />
         )}
       </>

--- a/packages/react/src/search/Search.tsx
+++ b/packages/react/src/search/Search.tsx
@@ -76,9 +76,6 @@ export const Search = forwardRef<SearchProps, "input">(
         ? `calc(${dimensions.borderBox.width}px + 0.5rem)`
         : "3rem";
 
-    console.log("inputPadding", inputPadding);
-    console.log("dimensions", dimensions?.borderBox.width);
-
     const paddingProp = (position: "left" | "right") => (position === "left" ? "paddingLeft" : "paddingRight");
 
     const RenderInputGroup = ({ position }: RenderProps) => (


### PR DESCRIPTION
Ender utformingen på search for å legge til muligheten for å legge til tekst på søkeknappen. 

Endringer:

- Legger til width i span på Icon for å sørge for at det ikke blir layout shift under lasting av Icon. 
- Fjerner left og right icon prop på Search (Breaking change - major changeset)
- Legger til muligheten å legge til tekst på Search ved å bruke enten iconButton eller searchButton. Det var ikke mulig å bruke en av de på grunn av at de er utformet litt forskjellig.

Kan se litt rart ut i storybook når man bytter props fordi det er en padding som blir regnet ut på render. 
