### PR TITLE
Komp-386-toc

### DIFF
--- a/apps/storybook/.storybook/MDXContainer.jsx
+++ b/apps/storybook/.storybook/MDXContainer.jsx
@@ -1,9 +1,21 @@
 // .storybook/MDXWrapper.tsx
-import React from "react";
+import React, { useEffect } from "react";
 import { KvibProvider } from "@kvib/react/src";
 import { DocsContainer, Story } from "@storybook/blocks";
 
 const MDXContainer = ({ children, ...props }) => {
+  // Remove table of contents if there are no h2 or h3 elements on the page
+  useEffect(() => {
+    document.querySelectorAll(".sbdocs-content").forEach((el) => {
+      const tocContainer = el.nextElementSibling;
+      const headings = el.querySelectorAll("h2, h3");
+
+      if (headings.length <= 1 && tocContainer) {
+        tocContainer.classList.add("toc-no-children");
+      }
+    });
+  }, []);
+
   return (
     <KvibProvider>
       <DocsContainer {...props}>

--- a/apps/storybook/.storybook/docs-root.css
+++ b/apps/storybook/.storybook/docs-root.css
@@ -130,3 +130,9 @@ input[type="range"]::-webkit-slider-thumb:active {
 .toc-no-children {
   display: none;
 }
+
+/* Headings for sections in docs */
+.docs-heading h2 {
+  border: none;
+  padding: 0;
+}

--- a/apps/storybook/.storybook/docs-root.css
+++ b/apps/storybook/.storybook/docs-root.css
@@ -125,3 +125,8 @@ input[type="range"]::-webkit-slider-thumb:active {
   max-height: 0;
   overflow: hidden;
 }
+
+/* Table of contents with no content */
+.toc-no-children {
+  display: none;
+}

--- a/apps/storybook/.storybook/docs-root.css
+++ b/apps/storybook/.storybook/docs-root.css
@@ -115,3 +115,13 @@ input[type="range"]::-moz-range-thumb:active {
 input[type="range"]::-webkit-slider-thumb:active {
   background: #156630;
 }
+
+/* Table of contents */
+.is-collapsible {
+  max-height: 1000px;
+  transition: all 300ms ease-in-out;
+}
+.is-collapsed {
+  max-height: 0;
+  overflow: hidden;
+}

--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -14,6 +14,12 @@ export const parameters = {
   docs: {
     theme: theme,
     container: MDXContainer,
+    toc: {
+      contentsSelector: ".sbdocs-content",
+      headingSelector: "h2, h3",
+      collapseDepth: 0,
+      title: "Innhold",
+    },
   },
   options: {
     storySort: {

--- a/apps/storybook/stories/design/ColorPalettes.tsx
+++ b/apps/storybook/stories/design/ColorPalettes.tsx
@@ -50,7 +50,7 @@ const Color = ({ value }: { value: string }) => {
           duration: 2000,
           isClosable: true,
         });
-      }
+      },
     );
   };
 
@@ -110,7 +110,7 @@ export const ColorPalettes = ({ hexColors, RGBAColors }: { hexColors: MapColorsT
       {RGBAColors !== undefined && <ColorFormatPicker format={format} setFormat={setFormat} />}
       {Object.entries(colors).map(([colorName, shades]) => (
         <Box key={colorName}>
-          <Heading as="h3" size="md">
+          <Heading as="h3" size="md" id={colorName}>
             {capitalizeFirstLetter(colorName)}
           </Heading>
           <Flex gap={5} flexWrap="wrap">

--- a/apps/storybook/stories/design/design-tokens/Colors.tsx
+++ b/apps/storybook/stories/design/design-tokens/Colors.tsx
@@ -62,7 +62,7 @@ export const Colors = () => {
     <Box marginBottom="40px">
       {Object.entries(colors).map(([name, colorScale]) => (
         <Box key={name} marginTop="20px">
-          <Heading size="md" as="h3">
+          <Heading size="md" as="h3" id={name}>
             {capitalizeFirstLetter(name)}
           </Heading>
           <Flex gap="8px" flexWrap="wrap">

--- a/apps/storybook/stories/design/design-tokens/design-tokens.mdx
+++ b/apps/storybook/stories/design/design-tokens/design-tokens.mdx
@@ -14,18 +14,6 @@ import { Link } from "@kvib/react/src";
 
 Nedenfor finner du en oversikt over alle design tokens i Kartverkets Designsystem.
 
-- <Link>[Farger](#farger)</Link>
-- <Link>[Typografi](#typografi)</Link>
-- <Link>[Breakpoints](#breakpoints)</Link>
-- <Link>[Spacing](#spacing)</Link>
-- <Link>[Sizes](#sizes)</Link>
-- <Link>[Radius](#radius)</Link>
-- <Link>[Z-index](#z-index)</Link>
-- <Link>[Transitions](#transitions)</Link>
-- <Link>[Borders](#borders)</Link>
-- <Link>[Shadows](#shadows)</Link>
-- <Link>[Blurs](#blurs)</Link>
-
 ## Farger
 
 Fargene brukes som CSS-variabler på følgende måte: `var(--kvib-colors-green-500)`.\

--- a/apps/storybook/stories/documentation/introduksjon.mdx
+++ b/apps/storybook/stories/documentation/introduksjon.mdx
@@ -5,6 +5,7 @@ import { Text, Code, Box, Heading, SimpleGrid } from "@kvib/react/src/";
 import * as IntroCards from "./IntroCard";
 
 <Meta title="Info/Introduksjon" />
+
 <Banner />
 
 <SimpleGrid columns={[1, 1, 2]} spacing={5}>

--- a/apps/storybook/stories/documentation/introduksjon.mdx
+++ b/apps/storybook/stories/documentation/introduksjon.mdx
@@ -5,7 +5,6 @@ import { Text, Code, Box, Heading, SimpleGrid } from "@kvib/react/src/";
 import * as IntroCards from "./IntroCard";
 
 <Meta title="Info/Introduksjon" />
-
 <Banner />
 
 <SimpleGrid columns={[1, 1, 2]} spacing={5}>

--- a/apps/storybook/stories/templates/DocsHeading.tsx
+++ b/apps/storybook/stories/templates/DocsHeading.tsx
@@ -15,6 +15,7 @@ export const DocsHeading = ({ children }: DocsHeadingProps) => {
       display="flex"
       marginBottom="2rem"
       marginTop="4rem"
+      className="docs-heading"
     >
       <Heading margin="0" color="white" size="sm" as="h2" id={children}>
         {children}

--- a/apps/storybook/stories/templates/DocsHeading.tsx
+++ b/apps/storybook/stories/templates/DocsHeading.tsx
@@ -1,7 +1,7 @@
 import { Box, Heading } from "@kvib/react/src";
 
 type DocsHeadingProps = {
-  children: React.ReactNode;
+  children: string;
 };
 
 export const DocsHeading = ({ children }: DocsHeadingProps) => {
@@ -16,7 +16,7 @@ export const DocsHeading = ({ children }: DocsHeadingProps) => {
       marginBottom="2rem"
       marginTop="4rem"
     >
-      <Heading margin="0" color="white" size="sm" as="h3">
+      <Heading margin="0" color="white" size="sm" as="h2" id={children}>
         {children}
       </Heading>
     </Box>

--- a/apps/storybook/stories/templates/DocsStory.tsx
+++ b/apps/storybook/stories/templates/DocsStory.tsx
@@ -11,7 +11,7 @@ export const DocsStory = ({ title, description, story, isVertical }: DocsStoryPr
   return (
     <SimpleGrid columns={[1, 1, isVertical ? 1 : 2]} spacing={[0, 0, isVertical ? 0 : "2rem"]}>
       <Box marginTop="25px">
-        <Heading size="md" as="h3">
+        <Heading size="md" as="h3" id={title}>
           {title}
         </Heading>
         <Text>{description}</Text>


### PR DESCRIPTION
Legger til innholdsfortegnelse! 

Storybook sin versjon av toc er litt buggy - jeg får ikke fjernet den på docs hvor det ikke helt lønner seg å ha den. For eksempel så vil headings fra stories (kode) også bli med i innholdsfortegnelse🤦‍♂️ 

Jeg har fikset den sånn at innholdsfortegnelsen forsvinner dersom det er mindre enn 2 headings på siden. 

Alt i alt vurderer jeg det som at det er bedre å ha den enn å ikke ha den på grunn av bugs. Den funker veldig smooth utenom det!

h2 og h3 vil bli med i innholdsfortegnelsen! 