### PR TITLE
Fikset dobbel retningslinjer banner

### DIFF
--- a/apps/storybook/stories/components/spinner/Spinner.mdx
+++ b/apps/storybook/stories/components/spinner/Spinner.mdx
@@ -57,17 +57,11 @@ import { Spinner } from "@kvib/react";
 Progress burde velges over spinner hvis man kan se prosentvis framgang, som f.eks. upload/download av filer, eller skjema med flere steg
 (Der kan stepper vurderes også). Spinner burde brukes over Progress uansett, så lenge ventetiden er minimal.
 
-</DocsContainer>
+### Ventetid
 
-<DocsHeading>Retningslinjer</DocsHeading>
-
-<DocsContainer>
-
-    ### Ventetid
-
-    Om bruker må vente, vil spinner bidra til å redusere usikkerhet. Det tar ikke lang tid før folk blir
-    utålmodige og/eller forvirra over at ingenting skjer. Hvis ventetiden overstiger 9 sekunder, bør bruker se en
-    forklaring sammen med Progress, og tekst som forklarer hva maskinen jobber med.
+Om bruker må vente, vil spinner bidra til å redusere usikkerhet. Det tar ikke lang tid før folk blir
+utålmodige og/eller forvirra over at ingenting skjer. Hvis ventetiden overstiger 9 sekunder, bør bruker se en
+forklaring sammen med Progress, og tekst som forklarer hva maskinen jobber med.
 
 </DocsContainer>
 


### PR DESCRIPTION
# Beskrivelse

fikset en liten feilkopiering ellernoe 
![image](https://github.com/kartverket/kvib/assets/122277136/79713843-91ee-4f66-b9e0-5b68e08eb1fa)
