### PR TITLE
komp-394-ikonstørrelse

### DIFF
--- a/.changeset/nice-guests-mix.md
+++ b/.changeset/nice-guests-mix.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+La til mulighet for alle størrelser på ikoner

--- a/apps/storybook/stories/design/Icon.stories.tsx
+++ b/apps/storybook/stories/design/Icon.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta<typeof Icon> = {
       defaultValue: { summary: 0 },
     },
     size: {
-      table: { type: { summary: "20 | 24 | 40 | 48" } },
+      table: { type: { summary: "20 | 24 | 40 | 48 | number" } },
       control: "radio",
       options: [20, 24, 40, 48],
       defaultValue: { summary: 24 },

--- a/packages/react/src/icon/Icon.tsx
+++ b/packages/react/src/icon/Icon.tsx
@@ -7,7 +7,7 @@ type IconProps = {
   icon: MaterialSymbol;
 
   /**The font size of the icon */
-  size?: 20 | 24 | 40 | 48;
+  size?: 20 | 24 | 40 | 48 | number;
 
   /**The color of the icon*/
   color?: string;


### PR DESCRIPTION
Legger til muligheten for å kunne endre på ikonstørrelse til hva som helst. Dette er slik at man kan lage mindre knapper med ikoner osv. 

Etter dette burde [komp-397](https://kartverket.atlassian.net/jira/software/projects/KOMP/boards/80?selectedIssue=KOMP-397) utvikles. 


![](https://media1.tenor.com/m/ZbmZDT16_FMAAAAC/merry-christmas-images-christmas.gif)
