### PR TITLE
Fix innholdsfortegnelse

### DIFF
--- a/apps/storybook/stories/documentation/komponenter/Components.tsx
+++ b/apps/storybook/stories/documentation/komponenter/Components.tsx
@@ -96,7 +96,7 @@ const ComponentCategory = ({
 }) => {
   return (
     <Box>
-      <Heading as="h3" size="md">
+      <Heading as="h3" size="md" id={title}>
         {title}
       </Heading>
       <Text marginBottom={"1.5rem"} fontSize="md">


### PR DESCRIPTION
Jeg så etter merge av komponentoversikt så fungerte ikke innholdsfortegnelse på den siden. 

Her kommer en kjapp fix - man må legge inn id på headings for at overskriften skal telles i innholdsfortegnelsen.
