### PR TITLE
prop for personvernerklæring

### DIFF
--- a/.changeset/chilled-stingrays-drive.md
+++ b/.changeset/chilled-stingrays-drive.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Lagt til prop for personvernerklæring i footer-inline

--- a/apps/storybook/stories/components/sideelementer/footer/footer-inline/FooterInline.stories.tsx
+++ b/apps/storybook/stories/components/sideelementer/footer/footer-inline/FooterInline.stories.tsx
@@ -18,6 +18,13 @@ const meta: Meta<typeof KvibFooterInline> = {
       },
       control: "text",
     },
+    privacyUrl: {
+      description: "Link to privacy statement",
+      table: {
+        type: { summary: "string" },
+      },
+      control: "text",
+    },
     logoLink: {
       description: "Href for logo link",
       table: {

--- a/packages/react/src/footer-inline/FooterInline.tsx
+++ b/packages/react/src/footer-inline/FooterInline.tsx
@@ -4,10 +4,18 @@ import { colors } from "../theme/tokens";
 type FooterInlineProps = {
   logoLink?: string;
   accessibilityUrl?: string;
+  /**The contact info email-adress
+   * @default https://kartverket.no/om-kartverket/personvern*/
+  privacyUrl?: string;
   children?: React.ReactNode;
 };
 
-export const FooterInline = ({ logoLink, accessibilityUrl, children }: FooterInlineProps) => {
+export const FooterInline = ({
+  logoLink,
+  accessibilityUrl,
+  privacyUrl = "https://kartverket.no/om-kartverket/personvern",
+  children,
+}: FooterInlineProps) => {
   return (
     <Flex
       borderTop={`1px solid ${colors.gray[300]}`}
@@ -26,11 +34,7 @@ export const FooterInline = ({ logoLink, accessibilityUrl, children }: FooterInl
             Tilgjengelighetserklæring
           </Link>
         )}
-        <Link
-          href="https://kartverket.no/om-kartverket/personvern"
-          aria-label="Besøk Kartverket sin personvernserklæring"
-          fontWeight="bold"
-        >
+        <Link href={privacyUrl} aria-label="Besøk Kartverket sin personvernserklæring" fontWeight="bold">
           Personvern
         </Link>
       </Flex>


### PR DESCRIPTION
# Beskrivelse
Team Smia har en egen personvernerklæring for nibas, som spesifikt forklarer hvorfor personnummer blir lagret i løsningen. Ønsket derfor en måte å override standardlenken til personvernerklæringen i komponenten `footer-inline`.

Det er ingen designendringer i denne PRen.

<img width="1008" alt="image" src="https://github.com/kartverket/kvib/assets/71885781/16c6506e-8a83-4fb9-8afb-27dee0504ad9">

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->

# Sjekkliste

<!-- Sjekk av disse punktene for hver endring -->

- [x] Sjekket at komponenten matcher designet i Figma
- [ ] Har fått design review med en designer
- [ ] Sjekket universell utforming for komponenten. Se for eksempel:
  - https://www.magentaa11y.com/web/
  - https://a11y-101.com/development
  - https://www.a11yproject.com/checklist/#appearance
- [x] Denne PR-en inneholder en enkelt komponent
