### PR TITLE
Lagt til storyes for å teste farge med ulik provider

### DIFF
--- a/apps/storybook/stories/components/skjemaelementer/timepicker/Timepicker.stories.tsx
+++ b/apps/storybook/stories/components/skjemaelementer/timepicker/Timepicker.stories.tsx
@@ -1,4 +1,13 @@
-import { FormControl, Timepicker as KvibTimepicker, FormLabel, Stack } from "@kvib/react/src";
+import {
+  FormControl,
+  Timepicker as KvibTimepicker,
+  FormLabel,
+  Stack,
+  extendTheme,
+  withDefaultColorScheme,
+  KvibProvider,
+  theme,
+} from "@kvib/react/src";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof KvibTimepicker> = {
@@ -152,4 +161,28 @@ export const TimepickerForm: Story = {
       <KvibTimepicker {...args} />
     </FormControl>
   ),
+};
+
+const greenTheme = extendTheme(withDefaultColorScheme({ colorScheme: "green" }), theme);
+
+export const TimepickerGreenProvider: Story = {
+  decorators: [
+    (Story) => (
+      <KvibProvider theme={greenTheme}>
+        <Story />
+      </KvibProvider>
+    ),
+  ],
+};
+
+const blueTheme = extendTheme(withDefaultColorScheme({ colorScheme: "blue" }), theme);
+
+export const TimepickerBlueProvider: Story = {
+  decorators: [
+    (Story) => (
+      <KvibProvider theme={blueTheme}>
+        <Story />
+      </KvibProvider>
+    ),
+  ],
 };


### PR DESCRIPTION
Jeg har lagt til to nye stories, som viser hvordan fargen settes for alle komponentene på en nettside via provideren som wrapper hele appen. Når koden virker akkurat som den skal så skal fargen til timepickeren bli riktig for begge storyene, ut i fra hvilket tema som er valgt i provideren.
