### PR TITLE
Endre fra KVIB til Kartverkets designsystem en rekke steder.

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -29,7 +29,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":mega: *En ny versjon av <https://kartverket.github.io/kvib|Kartverkets Designsystem> har blitt publisert!* :mega: \n\n Nyeste versjon: <https://kartverket.github.io/kvib/?path=/docs/info-changelog--docs|${{ steps.set_message.outputs.version }}>."
+                    "text": ":mega: *En ny versjon av <https://design.kartverket.no|Kartverkets Designsystem> har blitt publisert!* :mega: \n\n Nyeste versjon: <https://design.kartverket.no/?path=/docs/info-changelog--docs|${{ steps.set_message.outputs.version }}>."
                   }
                 }
               ]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # Kartverkets Designsystem
 
-Dokumentasjonssiden for designsystemet er https://kartverket.github.io/kvib. Der finner du bidragsløype, oppsett av designsystemet osv.
+Dokumentasjonssiden for designsystemet er https://design.kartverket.no. Der finner du bidragsløype, oppsett av designsystemet osv.
 
 ## 🚦 Viktig infomasjon eller kjøreregler for de som ønsker å bidra 🚦
 
 De som skal godkjenne pull requestene er:
 
 @Farhad Ahmadhadi  
-@Sebastian Maro  
-@Bente Lien Nilsen  
-@Adrian Røstgård Flatner
+@Bente Lien Nilsen
 
 Har dere spørsmål relatert til kode på Designsystemet kan dere kontakte dem.  
-Har dere design spørsmål kan dere kontakte @Wanni eller @Erlend Stølan.
+Har dere design spørsmål kan dere kontakte @line.marie.
 
 Eller bare #gen-designsystem på slack😊

--- a/apps/storybook/stories/components/sideelementer/header/Header.mdx
+++ b/apps/storybook/stories/components/sideelementer/header/Header.mdx
@@ -50,7 +50,7 @@ Defaultinnhold i dropdown menyen under headeren er samme children som headeren h
 
 ## Logo link
 
-Eksempel på logo link som går til Kvib. Default er "/".
+Eksempel på logo link som går til Kartverkets designsystem. Default er "/".
 
 <Canvas of={HeaderStories.HeaderLogoButton} />
 

--- a/apps/storybook/stories/components/sideelementer/header/Header.stories.tsx
+++ b/apps/storybook/stories/components/sideelementer/header/Header.stories.tsx
@@ -204,7 +204,7 @@ export const HeaderSearchAsync: Story = {
 
 export const HeaderLogoButton: Story = {
   args: {
-    logoLink: "https://kartverket.github.io/kvib/",
+    logoLink: "https://design.kartverket.no",
   },
   render: (args) => <KvibHeader {...args} />,
 };

--- a/apps/storybook/stories/documentation/bidra/Bygge.mdx
+++ b/apps/storybook/stories/documentation/bidra/Bygge.mdx
@@ -11,7 +11,7 @@ Link-komponenten brukes som eksempel under.
 
 1.  I `packages/react/src`: finn mappen med navnet på komponenten, dvs link.
 2.  I denne mappen (`packages/react/src/link`) lag én fil, _Link.tsx_ (i tillegg til _index.tsx_ som ligger der fra før).
-    _Link.tsx_ skal brukes for å kvibifisere komponenten med f.eks. egne props, og index.tsx brukes for å eksportere alt fra _.tsx_-filen.
+    _Link.tsx_ skal brukes for å tilpasse komponenten med f.eks. egne props, og index.tsx brukes for å eksportere alt fra _.tsx_-filen.
 3.  I _Link.tsx_: Begynn med å definere hvilke props som skal være gjeldende for din komponent, samt hvilke typer hver prop kan ta. Dette kan gjøres på to måter:
 
 - **Alternativ 1- bygg på Chakras props**: Importer Chakra sine props (her; LinkProps), og fjern unødvendige props og legg evt. til egendefinerte props.

--- a/apps/storybook/stories/documentation/bidra/KjenteProblemer.mdx
+++ b/apps/storybook/stories/documentation/bidra/KjenteProblemer.mdx
@@ -118,4 +118,4 @@ mens andre har props inkludert som er der for at man kan utvikle dem selv i them
 
 **Løsning**
 
-Ikke inkluder props som ikke endrer på komponentet eller har et annet formål i dokumentasjonen til KVIB.
+Ikke inkluder props som ikke endrer på komponentet eller har et annet formål i dokumentasjonen til Kartverkets designsystem.

--- a/apps/storybook/stories/documentation/bidra/Style.mdx
+++ b/apps/storybook/stories/documentation/bidra/Style.mdx
@@ -54,7 +54,7 @@ IconButton er en komponent hvor useStyleConfig er benyttet, og under vises det h
 <Alert status="warning">
   <AlertIcon />
   Du skal ikke sette default farge for en komponent direkte i komponenten. Vi har valgt å bruke grønt som default farge-tema
-  for de aller fleste komponentene i KVIB. Dette kan imidlertid enkelt endres til blått (se under Oppsett). Dersom et komponent
+  for de aller fleste komponentene i designsystemet. Dette kan imidlertid enkelt endres til blått (se under Oppsett). Dersom et komponent
   skal ha et annet default fargetema, f.eks grå, settes dette i theme/index.ts. På denne måten er det enkelt å holde oversikt
   over komponenter som avviker fra default fargetema.
 </Alert>

--- a/apps/storybook/stories/documentation/taIBruk.mdx
+++ b/apps/storybook/stories/documentation/taIBruk.mdx
@@ -32,11 +32,11 @@ function App() {
 export default App;
 ```
 
-I eksempelet over har vi også lagt til en knapp som viser hvordan du tar i bruk et KVIB-komponent i applikasjonen din.
+I eksempelet over har vi også lagt til en knapp som viser hvordan du tar i bruk et designsystem-komponent i applikasjonen din.
 
 ## Endre default-farge
 
-Default farge-tema for KVIB er grønt. Dette skal gjelde for alle applikasjoner som skal ligne Kartverket.no i stylingen.
+Default farge-tema for Kartverkets designsystem er grønt. Dette skal gjelde for alle applikasjoner som skal ligne Kartverket.no i stylingen.
 For applikasjoner med skjema og karttjenester skal man imidlertid benytte blått fargetema.
 Dette gjøres ved å legge til et customTheme med colorScheme: "blue", og benytte det i KVIB-provideren slik:
 
@@ -64,7 +64,7 @@ export default App;
     <Alert status="info">
         <AlertIcon/>
         <AlertDescription>
-            I utgangspunktet skal man benytte komponentene fra Kartverkets designbibliotek med stylingen som er der. Er
+            I utgangspunktet skal man benytte komponentene fra Kartverkets designsystem med stylingen som er der. Er
             det
             funksjoner og design du synes mangler i dagens bibliotek, ønsker vi at du bidrar med dette til biblioteket
             istedenfor å overskrive stylingen i eget prosjekt- da kan fler enn deg ta det i bruk! Se [dokumentasjonen
@@ -117,8 +117,8 @@ export default function App() {
 
 ## Obs om import
 
-I og med at KVIB inneholder hele Chakra-biblioteket har noen brukere opplevd at de ved et
-uhell har tatt i brukt chakra-komponenter i steden for kvib-komponenter, og at dette har ført til uheldig oppførsel. Eks:
+I og med at Kartverkets designsystem inneholder hele Chakra-biblioteket har noen brukere opplevd at de ved et
+uhell har tatt i brukt chakra-komponenter i steden for designsystem-komponenter, og at dette har ført til uheldig oppførsel. Eks:
 
 ```tsx
 import { NumberInput, NumberInputField } from "@kvib/react";
@@ -135,7 +135,7 @@ const Eksempel = () => (
 );
 ```
 
-Siden KVIB tilbyr alle de samme komponentene som Chakra skal ikke dette være nødvendig, men det kan fort skje ved en feil ved at
+Siden Kartverkets designsystem tilbyr alle de samme komponentene som Chakra skal ikke dette være nødvendig, men det kan fort skje ved en feil ved at
 VS-code eller Idea foreslår å importere fra feil pakke.
 For å unngå problemet er det mulig å sette innstillinger i editoren din til å hindre import forslag fra Chakra, eller å legge inn følgende regel i es-lint:
 


### PR DESCRIPTION
# Beskrivelse

Fjernet ordet KVIB fra alle steder jeg fant det i tekst og beskrivelser, og byttet ut med Kartverkets designsystem eller designsystemet. Jeg har også oppdatert URL-en, der hvor det var brukt gammel url for dokumentasjonssiden.

Ordet KVIB er fremdeles veldig mye brukt i kode, det er ikke endret i denne pull-requesten.