### PR TITLE
Fjern isSelected fra tab

### DIFF
--- a/apps/storybook/stories/components/navigasjon/tabs/tab.stories.tsx
+++ b/apps/storybook/stories/components/navigasjon/tabs/tab.stories.tsx
@@ -23,14 +23,6 @@ const meta: Meta<typeof KvibTab> = {
   },
 
   argTypes: {
-    isSelected: {
-      description: "If tab is selected or not.",
-      table: {
-        type: { summary: Boolean },
-        defaultValue: { summary: false },
-      },
-      control: { type: "boolean" },
-    },
     panelId: {
       description: "The id of the panel.",
       table: {


### PR DESCRIPTION
# Beskrivelse

isSelected er ikke en property i `<Tab>` komponenten, men det er dokumentasjon i storybook som viser det, isSelected gjør altså ingenting.