### PR TITLE
Komp-439-test-runner

### DIFF
--- a/apps/storybook/.storybook/test-runner.ts
+++ b/apps/storybook/.storybook/test-runner.ts
@@ -9,6 +9,9 @@ import type { TestRunnerConfig } from "@storybook/test-runner";
  * to learn more about the test-runner hooks API.
  */
 const a11yConfig: TestRunnerConfig = {
+  tags: {
+    exclude: ["no-tests"],
+  },
   async preVisit(page) {
     await injectAxe(page);
   },

--- a/apps/storybook/stories/components/skjemaelementer/timepicker/Timepicker.stories.tsx
+++ b/apps/storybook/stories/components/skjemaelementer/timepicker/Timepicker.stories.tsx
@@ -166,6 +166,7 @@ export const TimepickerForm: Story = {
 const greenTheme = extendTheme(withDefaultColorScheme({ colorScheme: "green" }), theme);
 
 export const TimepickerGreenProvider: Story = {
+  tags: ["no-tests"],
   decorators: [
     (Story) => (
       <KvibProvider theme={greenTheme}>
@@ -178,6 +179,7 @@ export const TimepickerGreenProvider: Story = {
 const blueTheme = extendTheme(withDefaultColorScheme({ colorScheme: "blue" }), theme);
 
 export const TimepickerBlueProvider: Story = {
+  tags: ["no-tests"],
   decorators: [
     (Story) => (
       <KvibProvider theme={blueTheme}>


### PR DESCRIPTION
# Beskrivelse

Added tags to test-runner config file, excluded Timepicker green and blue providers from accessibility tests.