### PR TITLE
Komp-454: Støtte for å skjule aria på ikoner

### DIFF
--- a/.changeset/tame-zebras-happen.md
+++ b/.changeset/tame-zebras-happen.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+Added option for disabling aria for Icon

--- a/apps/storybook/stories/components/media/icon/Icon.stories.tsx
+++ b/apps/storybook/stories/components/media/icon/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import { Icon, HStack, useTheme } from "@kvib/react/src";
+import { HStack, Icon, useTheme } from "@kvib/react/src";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof Icon> = {
@@ -33,6 +33,11 @@ const meta: Meta<typeof Icon> = {
       defaultValue: { summary: 24 },
     },
     isFilled: {
+      table: { type: { summary: "boolean" } },
+      control: "boolean",
+      defaultValue: { summary: false },
+    },
+    ariaIsHidden: {
       table: { type: { summary: "boolean" } },
       control: "boolean",
       defaultValue: { summary: false },

--- a/packages/react/src/icon/Icon.tsx
+++ b/packages/react/src/icon/Icon.tsx
@@ -1,5 +1,5 @@
-import { MaterialSymbol } from "material-symbols";
 import "material-symbols";
+import { MaterialSymbol } from "material-symbols";
 import { forwardRef } from "../hooks";
 
 type IconProps = {
@@ -21,15 +21,19 @@ type IconProps = {
   /**Decides whether the icon is filled or not*/
   isFilled?: boolean;
 
+  /**Decides whether a screen reader will vocalize the icon name or not */
+  ariaIsHidden?: boolean;
+
   className?: string;
 };
 
 export const Icon = forwardRef<IconProps, "span">(
-  ({ icon, size, color, weight, grade, isFilled = false, className = "" }, ref) => {
+  ({ icon, size, color, weight, grade, isFilled = false, ariaIsHidden = false, className = "" }, ref) => {
     return (
       <span
         ref={ref}
         className={`material-symbols-rounded ${className}`}
+        aria-hidden={ariaIsHidden}
         style={{
           width: size,
           fontSize: size,


### PR DESCRIPTION
# Beskrivelse

La til et valg for å sette `aria-hidden` til `true` for ikoner for å gjøre det mulig å hindre at skjermlesere leser opp ikonnavnet fra Material Symbols.


# Sjekkliste

<!-- Sjekk av disse punktene for hver endring -->

- [x] Sjekket at komponenten matcher designet i Figma
- [x] Har fått design review med en designer
- [x] Sjekket universell utforming for komponenten. Se for eksempel:
  - https://www.magentaa11y.com/web/
  - https://a11y-101.com/development
  - https://www.a11yproject.com/checklist/#appearance
- [x] Denne PR-en inneholder en enkelt komponent
