### PR TITLE
Komp-454-2: Støtte for å skjule aria på ikoner tilhørende knapper

### DIFF
--- a/.changeset/tall-bikes-change.md
+++ b/.changeset/tall-bikes-change.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+Added option for disabling aria for Icon inside Button component

--- a/apps/storybook/stories/components/knapper/button/Button.stories.tsx
+++ b/apps/storybook/stories/components/knapper/button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { Button as KvibButton, VStack, StackDivider, ButtonGroup as KvibButtonGroup } from "@kvib/react/src";
+import { Button as KvibButton, ButtonGroup as KvibButtonGroup, StackDivider, VStack } from "@kvib/react/src";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof KvibButton> = {
@@ -50,6 +50,11 @@ const meta: Meta<typeof KvibButton> = {
         type: { summary: "boolean" },
       },
       control: "boolean",
+    },
+    iconAriaIsHidden: {
+      table: { type: { summary: "boolean" } },
+      control: "boolean",
+      defaultValue: { summary: false },
     },
   },
 };

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -1,10 +1,10 @@
 import {
+  Center,
   Button as ChakraButton,
   ButtonProps as ChakraButtonProps,
-  Center,
-  forwardRef,
-  Spinner,
   HStack,
+  Spinner,
+  forwardRef,
 } from "@chakra-ui/react";
 import { MaterialSymbol } from "material-symbols";
 import { Icon } from "../icon";
@@ -28,10 +28,13 @@ export type ButtonProps = Omit<
   iconFill?: boolean;
 
   variant?: "primary" | "secondary" | "tertiary" | "ghost";
+
+  /**Decides whether a screen reader will vocalize the icon name or not */
+  iconAriaIsHidden?: boolean;
 };
 
 export const Button = forwardRef<ButtonProps, "button">(
-  ({ children, iconFill, isDisabled, isLoading, leftIcon, rightIcon, ...props }, ref) => {
+  ({ children, iconFill, isDisabled, isLoading, leftIcon, rightIcon, iconAriaIsHidden, ...props }, ref) => {
     return (
       <ChakraButton {...props} ref={ref} isDisabled={isDisabled || isLoading} aria-busy={isLoading}>
         {isLoading && (
@@ -41,13 +44,23 @@ export const Button = forwardRef<ButtonProps, "button">(
         )}
         <HStack spacing={1} visibility={isLoading ? "hidden" : "visible"}>
           {leftIcon && (
-            <Icon icon={leftIcon} isFilled={iconFill} size={props.size === "xs" || props.size === "sm" ? 20 : 24} />
+            <Icon
+              icon={leftIcon}
+              ariaIsHidden={iconAriaIsHidden}
+              isFilled={iconFill}
+              size={props.size === "xs" || props.size === "sm" ? 20 : 24}
+            />
           )}
           <Center className="text" as="span">
             {children}
           </Center>
           {rightIcon && (
-            <Icon icon={rightIcon} isFilled={iconFill} size={props.size === "xs" || props.size === "sm" ? 20 : 24} />
+            <Icon
+              icon={rightIcon}
+              ariaIsHidden={iconAriaIsHidden}
+              isFilled={iconFill}
+              size={props.size === "xs" || props.size === "sm" ? 20 : 24}
+            />
           )}
         </HStack>
       </ChakraButton>


### PR DESCRIPTION
# Beskrivelse

Bruker utvider `Button` til å kunne ta inn en prop for om `ariaIsHidden` skal bli satt på tilhørende ikon for vanlige knapper med `rightIcon` og `leftIcon`. Dette bør nok ikke være et valg på vanlig `IconButton` siden aria-label bør settes uansett når disse komponentene ikke inneholder annen tekst uansett, så har derfor valgt å kun utvide den vanlige `Button`.

Denne kan brukes for å unngå at en `<Button leftIcon="login">Logg inn</Button>` leses opp som "login Logg inn" av en skjermleser.

# Sjekkliste

<!-- Sjekk av disse punktene for hver endring -->

- [x] Sjekket at komponenten matcher designet i Figma
- [x] Har fått design review med en designer
- [x] Sjekket universell utforming for komponenten. Se for eksempel:
  - https://www.magentaa11y.com/web/
  - https://a11y-101.com/development
  - https://www.a11yproject.com/checklist/#appearance
- [x] Denne PR-en inneholder en enkelt komponent
