### PR TITLE
Setter default datepicker colorscheme på theme-nivå

### DIFF
--- a/.changeset/tasty-geese-buy.md
+++ b/.changeset/tasty-geese-buy.md
@@ -1,0 +1,6 @@
+---
+"@kvib/storybook": patch
+"@kvib/react": patch
+---
+
+Setter default datepicker colorscheme på theme-nivå

--- a/apps/storybook/stories/documentation/bidra/Bygge.mdx
+++ b/apps/storybook/stories/documentation/bidra/Bygge.mdx
@@ -65,7 +65,7 @@ videre på denne._
     og [The as prop and Custom component](https://chakra-ui.com/community/recipes/as-prop).
 
 ````jsx
-export const Link = forwardRef < LinkProps, "a">(({children, colorScheme = "green", ...props}, ref) => {
+export const Link = forwardRef < LinkProps, "a">(({children, ...props}, ref) => {
     const isExternal = props.isExternal !== undefined ? props.isExternal : Boolean(props.href?.match(/^https?:\/\//));
     return (
         <ChakraLink {...props} ref={ref} colorScheme={colorScheme} isExternal={isExternal}>

--- a/packages/react/src/datepicker/Datepicker.tsx
+++ b/packages/react/src/datepicker/Datepicker.tsx
@@ -130,17 +130,18 @@ const CustomDatepicker = forwardRef<DatepickerProps, "input">(
       showOutsideDays,
       showWeekNumber,
       disabledDays,
+      colorScheme,
       isDisabled: isDisabledExternally = false,
       isInvalid: isInvalidExternally = false,
       isRequired: isRequiredExternally = false,
-      colorScheme = "green",
       ...KVInputProps
     },
     ref,
   ) => {
     // Style for the day picker
     const uniqueClassName = generateUniqueClassName("kvib-datepicker");
-    const style = css(uniqueClassName, colorScheme);
+    const themeColorScheme = theme.components.Datepicker.defaultProps.colorScheme;
+    const style = css(uniqueClassName, colorScheme ?? themeColorScheme);
 
     // Get state from form control context
     const formControlContext = useFormControlContext();

--- a/packages/react/src/theme/components/datepicker.ts
+++ b/packages/react/src/theme/components/datepicker.ts
@@ -1,0 +1,7 @@
+import { defineStyleConfig } from "@chakra-ui/react";
+
+export const datepickerTheme = defineStyleConfig({
+  defaultProps: {
+    colorScheme: "green",
+  },
+});

--- a/packages/react/src/theme/components/index.ts
+++ b/packages/react/src/theme/components/index.ts
@@ -14,3 +14,4 @@ export { breadcrumbTheme as Breadcrumb } from "./breadcrumb";
 export { timepickerTheme as Timepicker } from "./timepicker";
 export { fileUploadTheme as FileUpload } from "./fileUpload";
 export { alertTheme as Alert } from "./alert";
+export { datepickerTheme as Datepicker } from "./datepicker";


### PR DESCRIPTION
# Beskrivelse

Dersom man setter default fargetema som instruert i [dokumentasjonen](https://design.kartverket.no/?path=/docs/info-oppsett--docs#endre-default-farge) vil ikke Datepicker bli satt til riktig farge. Det kommer av at dere setter default colorScheme på komponentnivå og lytter ikke på verdien som er satt i theme. Da må konsumentene sette colorScheme til f.eks. `blue` hvert eneste sted komponent brukes, og det kan fikses.

Dette skal ikke føre til noen merkbar endring for de fleste brukerne.

Fjernet også eksempel av feilaktig bruk fra Bygge.mdx