### PR TITLE
Omdøp theme og fiks bruk av theme til datepickers

### DIFF
--- a/.changeset/eighty-fireants-buy.md
+++ b/.changeset/eighty-fireants-buy.md
@@ -1,0 +1,6 @@
+---
+"@kvib/storybook": patch
+"@kvib/react": major
+---
+
+Omdøp theme og fiks bruk av theme til datepickers

--- a/apps/storybook/.storybook/preview.js
+++ b/apps/storybook/.storybook/preview.js
@@ -1,5 +1,5 @@
 import { KvibProvider } from "@kvib/react/src";
-// import { extendTheme, theme as KvibTheme, withDefaultColorScheme } from "@kvib/react/src";
+// import { extendTheme, defaultKvibTheme, withDefaultColorScheme } from "@kvib/react/src";
 import theme from "./theme";
 import MDXContainer from "./MDXContainer";
 import "./docs-root.css";
@@ -52,7 +52,7 @@ export const parameters = {
 };
 
 // For å teste storyene slik de vil se ut med endret default-farge kan du kommentere inn denne linja, og bruke themet i KVIBProvideren. Husk å kommentere inn importer også!
-// const customTheme = extendTheme(withDefaultColorScheme({ colorScheme: "blue" }), KvibTheme);
+// const customTheme = extendTheme(withDefaultColorScheme({ colorScheme: "blue" }), defaultKvibTheme);
 
 export const decorators = [
   (Story) => (

--- a/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.mdx
+++ b/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.mdx
@@ -25,11 +25,12 @@ import { Datepicker } from "@kvib/react";
 - Valg av dato langt tilbake eller frem i tid
 
 <Alert status="warning">
-          <AlertIcon/>
-          <AlertDescription>
-            Datepicker er fremdeles noe uferdig. Vi jobber fortløpende med å rette feil og forbedre funksjonaliteten, og det vil derfor forekomme noen api-endringer fremover.
-            Kjente problemer er at vi ikke gir feilmelding dersom bruker taster inn ugyldig dato, og at onChange ikke trigges når brukeren fjerner en inntastet dato.
-          </AlertDescription>
+  <AlertIcon />
+  <AlertDescription>
+    Datepicker er fremdeles noe uferdig. Vi jobber fortløpende med å rette feil og forbedre funksjonaliteten, og det vil
+    derfor forekomme noen api-endringer fremover. Kjente problemer er at vi ikke gir feilmelding dersom bruker taster
+    inn ugyldig dato, og at onChange ikke trigges når brukeren fjerner en inntastet dato.
+  </AlertDescription>
 </Alert>
 
 <Feedback component="Datepicker" />
@@ -67,8 +68,8 @@ import { Datepicker } from "@kvib/react";
   title="Datepicker i form"
   description={
     <Text>
-      Ved å benytte seg av Datepicker sammen med <Code>Form Control</Code> vil du få kontekst som <Code>isInvalid</Code>,
-      <Code>isDisabled</Code> og
+      Ved å benytte seg av Datepicker sammen med <Code>Form Control</Code> vil du få kontekst som <Code>isInvalid</Code>
+      ,<Code>isDisabled</Code> og
       <Code>isRequired</Code>. Slik vil det også være enkelt å legge til en label.
     </Text>
   }
@@ -88,13 +89,6 @@ import { Datepicker } from "@kvib/react";
       </Text>
       <Text>
         Det er mulig å velge mellom to colorSchemes: <Code>"blue"</Code> og <Code>"green"</Code>
-        <Alert status="warning">
-          <AlertIcon/>
-          <AlertDescription>
-            De fleste komponentene bytter automatisk til riktig colorScheme basert på colorScheme valgt i oppsett av KvibProvider. 
-            På data-picker må dette foreløpig settes manuelt hver gang den brukes for å få blått colorScheme!
-          </AlertDescription>      
-        </Alert>
       </Text>
     </Box>
   }

--- a/apps/storybook/stories/components/skjemaelementer/timepicker/Timepicker.stories.tsx
+++ b/apps/storybook/stories/components/skjemaelementer/timepicker/Timepicker.stories.tsx
@@ -6,7 +6,7 @@ import {
   extendTheme,
   withDefaultColorScheme,
   KvibProvider,
-  theme,
+  defaultKvibTheme,
 } from "@kvib/react/src";
 import { Meta, StoryObj } from "@storybook/react";
 
@@ -163,7 +163,7 @@ export const TimepickerForm: Story = {
   ),
 };
 
-const greenTheme = extendTheme(withDefaultColorScheme({ colorScheme: "green" }), theme);
+const greenTheme = extendTheme(withDefaultColorScheme({ colorScheme: "green" }), defaultKvibTheme);
 
 export const TimepickerGreenProvider: Story = {
   tags: ["no-tests"],
@@ -176,7 +176,7 @@ export const TimepickerGreenProvider: Story = {
   ],
 };
 
-const blueTheme = extendTheme(withDefaultColorScheme({ colorScheme: "blue" }), theme);
+const blueTheme = extendTheme(withDefaultColorScheme({ colorScheme: "blue" }), defaultKvibTheme);
 
 export const TimepickerBlueProvider: Story = {
   tags: ["no-tests"],

--- a/apps/storybook/stories/documentation/taIBruk.mdx
+++ b/apps/storybook/stories/documentation/taIBruk.mdx
@@ -43,9 +43,9 @@ Dette gjøres ved å legge til et customTheme med colorScheme: "blue", og benytt
 ```tsx
 // I din src/app.tsx fil:
 import "./App.css";
-import { Button, KvibProvider, extendTheme, theme, withDefaultColorScheme } from "@kvib/react";
+import { Button, KvibProvider, extendTheme, defaultKvibTheme, withDefaultColorScheme } from "@kvib/react";
 
-const customTheme = extendTheme(withDefaultColorScheme({ colorScheme: "blue" }), theme);
+const customTheme = extendTheme(withDefaultColorScheme({ colorScheme: "blue" }), defaultKvibTheme);
 
 function App() {
   return (
@@ -223,7 +223,7 @@ hydrate(
   <ClientCacheProvider>
     <RemixBrowser />
   </ClientCacheProvider>,
-  document
+  document,
 );
 ```
 
@@ -242,7 +242,7 @@ export default function handleRequest(
   request: Request,
   responseStatusCode: number,
   responseHeaders: Headers,
-  remixContext: EntryContext
+  remixContext: EntryContext,
 ) {
   const cache = createEmotionCache();
   const { extractCriticalToChunks } = createEmotionServer(cache);
@@ -252,7 +252,7 @@ export default function handleRequest(
       <CacheProvider value={cache}>
         <RemixServer context={remixContext} url={request.url} />
       </CacheProvider>
-    </ServerStyleContext.Provider>
+    </ServerStyleContext.Provider>,
   );
 
   const chunks = extractCriticalToChunks(html);
@@ -262,7 +262,7 @@ export default function handleRequest(
       <CacheProvider value={cache}>
         <RemixServer context={remixContext} url={request.url} />
       </CacheProvider>
-    </ServerStyleContext.Provider>
+    </ServerStyleContext.Provider>,
   );
 
   responseHeaders.set("Content-Type", "text/html");

--- a/packages/react/src/datepicker/Datepicker.tsx
+++ b/packages/react/src/datepicker/Datepicker.tsx
@@ -8,7 +8,7 @@ import {
   InputRightElement,
   PopoverTrigger,
   PopoverAnchor,
-  theme,
+  useTheme,
   IconButton,
 } from "@kvib/react/src";
 import { forwardRef, useFormControlContext } from "@chakra-ui/react";
@@ -138,10 +138,14 @@ const CustomDatepicker = forwardRef<DatepickerProps, "input">(
     },
     ref,
   ) => {
+    const theme = useTheme();
+
     // Style for the day picker
     const uniqueClassName = generateUniqueClassName("kvib-datepicker");
-    const themeColorScheme = theme.components.Datepicker.defaultProps.colorScheme;
-    const style = css(uniqueClassName, colorScheme ?? themeColorScheme);
+    const style = css(
+      uniqueClassName,
+      theme.colors[colorScheme ?? theme.components.Datepicker.defaultProps.colorScheme],
+    );
 
     // Get state from form control context
     const formControlContext = useFormControlContext();
@@ -216,7 +220,7 @@ const CustomDatepicker = forwardRef<DatepickerProps, "input">(
             <PopoverTrigger>
               <IconButton
                 icon="calendar_today"
-                colorScheme={colorScheme as "blue" | "green"}
+                colorScheme={colorScheme}
                 size={KVInputProps.size}
                 aria-label="open datepicker"
                 onClick={setPickerVisible.toggle}
@@ -298,13 +302,13 @@ const getCommonInputProps = (props: DatepickerProps) => {
 };
 
 // Function to generate the css for the day picker
-const css = (className: string, colorScheme: "blue" | "green") => {
+const css = (className: string, colorPalette: Record<number, string>) => {
   return `
  .${className} {
   --rdp-cell-size: 40px; /* Size of the day cells. */
   --rdp-caption-font-size: 18px; /* Font size for the caption labels. */
-  --rdp-accent-color: ${theme.colors[colorScheme][500]}; /* Accent color for the background of selected days. */
-  --rdp-background-color: ${theme.colors[colorScheme][50]}; /* Background color for the hovered/focused elements. */
+  --rdp-accent-color: ${colorPalette[500]}; /* Accent color for the background of selected days. */
+  --rdp-background-color: ${colorPalette[50]}; /* Background color for the hovered/focused elements. */
   --rdp-outline: 2px solid var(--rdp-accent-color); /* Outline border for focused elements */
   --rdp-selected-color: #fff; /* Color of selected day text */
 }

--- a/packages/react/src/header/Header.tsx
+++ b/packages/react/src/header/Header.tsx
@@ -7,7 +7,7 @@ import {
   useDisclosure,
   VStack,
   Collapse,
-  theme,
+  defaultKvibTheme,
   Link,
 } from "@kvib/react/src";
 
@@ -50,8 +50,8 @@ export const Header = (props: HeaderProps) => {
     logoVariant = "horizontal",
   } = props;
 
-  const [isCollapse] = useMediaQuery(`(max-width: ${theme.breakpoints[collapseBreakpoint]})`);
-  const [isSm] = useMediaQuery(`(max-width: ${theme.breakpoints["sm"]})`);
+  const [isCollapse] = useMediaQuery(`(max-width: ${defaultKvibTheme.breakpoints[collapseBreakpoint]})`);
+  const [isSm] = useMediaQuery(`(max-width: ${defaultKvibTheme.breakpoints["sm"]})`);
   const logoHorizontalSize = isSm ? 110 : 150;
   const logoVerticalSize = isSm ? 70 : 100;
   const headerSize = isSm ? 70 : 90;

--- a/packages/react/src/provider/KvibProvider.tsx
+++ b/packages/react/src/provider/KvibProvider.tsx
@@ -4,7 +4,7 @@ import "@fontsource/mulish/700.css";
 import "material-symbols";
 
 import { ChakraProvider, ChakraProviderProps } from "@chakra-ui/react";
-import { theme as defaultKvibTheme } from "../";
+import { defaultKvibTheme } from "../";
 
 /**
  * KVIBProvider er komponenten som gir de andre komponentene riktig tema og stil

--- a/packages/react/src/theme/index.ts
+++ b/packages/react/src/theme/index.ts
@@ -2,7 +2,7 @@ import { extendTheme, withDefaultColorScheme } from "@chakra-ui/react";
 import * as components from "./components";
 import * as tokens from "./tokens";
 
-export const theme = extendTheme(
+export const defaultKvibTheme = extendTheme(
   withDefaultColorScheme({ colorScheme: "green" }),
   withDefaultColorScheme({ colorScheme: "gray", components: ["Badge", "Code", "Table", "Tag"] }),
   {

--- a/packages/react/src/timepicker/Timepicker.tsx
+++ b/packages/react/src/timepicker/Timepicker.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { IconButton, Input, theme } from "@kvib/react/src";
+import { IconButton, Input, defaultKvibTheme } from "@kvib/react/src";
 import { useTimeFieldState } from "react-stately";
 import { TimeValue } from "@react-types/datepicker";
 import { CalendarDateTime, parseTime } from "@internationalized/date";
@@ -135,13 +135,13 @@ const getFocusStyles = (
       case "outline":
         return {
           borderColor: "blue.500",
-          boxShadow: `0 0 0 1px ${theme.colors.blue[500]}`,
+          boxShadow: `0 0 0 1px ${defaultKvibTheme.colors.blue[500]}`,
           _hover: { borderColor: isInvalid ?? "blue.500" },
         };
       case "flushed":
         return {
           borderColor: "blue.500",
-          boxShadow: `0 1px 0 0 ${theme.colors.blue[500]}`,
+          boxShadow: `0 1px 0 0 ${defaultKvibTheme.colors.blue[500]}`,
           _hover: { borderColor: isInvalid ?? "blue.500" },
         };
       default:


### PR DESCRIPTION
Gikk litt fort i svingene sist (#779), testingen fungerte innad i kvib, men ikke som en ekstern pakke. Problemet kommer av at når man bruker `theme`-konstanten i kvib så henter man i praksis ned _default_ theme, ikke theme-verdien som mates inn i KvibProvider. Med andre ord ville ikke eksterne temaer fungere fordi kvib bare brukte sitt eget default theme uansett hva. Løsningen er å bruker `useTheme`-hooken som henter theme fra KvibContext i stedet, enkelt og greit.

Dette er et problem som egentlig ligger ganske mange steder i kodebasen, men er i hovedsak knyttet til bruk av farger. Siden konsumenter av designsystemer antageligvis bruker de samme fargepalettene så kommer ikke det til å bli et problem med det første, men det er noe noen™️ bør se på å bytte ut. Det gjelder også tilfeller der man importerer fra theme/tokens eller liknende. For at designsystemet skal være fleksibelt må man arve fra temaet som sendes inn i KvibProvider.

Siden skillet mellom theme og useTheme var litt uintuitivt har jeg endret navet på `theme` til `defaultKvibTheme`. Det er strengt tatt en breaking change, så da må vel dette bli kvib 4.0.0.


