### PR TITLE
Add optionLabelFormatter for SearchAsync

### DIFF
--- a/.changeset/ninety-lobsters-grab.md
+++ b/.changeset/ninety-lobsters-grab.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+La til optionLabelFormatter for AsyncSearch

--- a/apps/storybook/stories/components/search/search-async/SearchAsync.stories.tsx
+++ b/apps/storybook/stories/components/search/search-async/SearchAsync.stories.tsx
@@ -197,8 +197,7 @@ export const SearchAsyncResults: Story = {
   ),
 };
 
-const boldAndBadgeLabelFormatter = (data: Fruit, formatOptionLabelMeta: FormatOptionLabelMeta<Fruit>) => {
-  console.log(data, formatOptionLabelMeta);
+const boldAndBadgeLabelFormatter = (data: Fruit) => {
   return (
     <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
       <b>{data.label}</b>

--- a/apps/storybook/stories/components/search/search-async/SearchAsync.stories.tsx
+++ b/apps/storybook/stories/components/search/search-async/SearchAsync.stories.tsx
@@ -1,5 +1,14 @@
-import { SearchAsync as KvibSearchAsync, Stack as KvibStack, Box, Icon, Text } from "@kvib/react/src";
+import {
+  SearchAsync as KvibSearchAsync,
+  Stack as KvibStack,
+  Box,
+  Icon,
+  Text,
+  SearchAsyncProps,
+  Badge,
+} from "@kvib/react/src";
 import { Meta, StoryObj } from "@storybook/react";
+import { FormatOptionLabelMeta } from "chakra-react-select";
 
 const meta: Meta<typeof KvibSearchAsync> = {
   title: "Søk/SearchAsync",
@@ -101,6 +110,12 @@ const meta: Meta<typeof KvibSearchAsync> = {
       },
       control: "text",
     },
+    optionLabelFormatter: {
+      table: {
+        type: { summary: "(data: T, formatOptionLabelMeta: FormatOptionLabelMeta<T>) => ReactNode" },
+      },
+      control: "text",
+    },
     isDisabled: {
       table: {
         type: { summary: "boolean" },
@@ -120,7 +135,8 @@ const meta: Meta<typeof KvibSearchAsync> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof KvibSearchAsync>;
+type Fruit = { label: string; value: string };
+type Story = StoryObj<typeof KvibSearchAsync<Fruit>>;
 
 export const SearchAsync: Story = {
   args: {},
@@ -138,7 +154,7 @@ export const SearchAsync: Story = {
   ),
 };
 
-const fruits = [
+const fruits: Fruit[] = [
   { label: "Eple", value: "eple" },
   { label: "Banan", value: "banan" },
   { label: "Kirsebær", value: "kirsebær" },
@@ -174,7 +190,32 @@ export const SearchAsyncResults: Story = {
     placeholder: "Søk etter frukt...",
     isMulti: false,
   },
-  render: (args) => (
+  render: (args: SearchAsyncProps<Fruit>) => (
+    <Box h="20rem">
+      <KvibSearchAsync {...args} />
+    </Box>
+  ),
+};
+
+const boldAndBadgeLabelFormatter = (data: Fruit, formatOptionLabelMeta: FormatOptionLabelMeta<Fruit>) => {
+  console.log(data, formatOptionLabelMeta);
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%" }}>
+      <b>{data.label}</b>
+      {data.label === "Kiwi" ? <Badge>Frukt (ekkel)</Badge> : <Badge>Frukt</Badge>}
+    </div>
+  );
+};
+
+export const SearchAsyncResultsFormatted: Story = {
+  args: {
+    loadOptions: mockLoadOptions,
+    onChange: handleChange,
+    optionLabelFormatter: boldAndBadgeLabelFormatter,
+    placeholder: "Søk etter frukt...",
+    isMulti: false,
+  },
+  render: (args: SearchAsyncProps<Fruit>) => (
     <Box h="20rem">
       <KvibSearchAsync {...args} />
     </Box>

--- a/packages/react/src/search-async/SearchAsync.tsx
+++ b/packages/react/src/search-async/SearchAsync.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useEffect, useRef } from "react";
 import { Text } from "@kvib/react/src";
-import { ActionMeta, AsyncSelect as ReactSearch } from "chakra-react-select";
+import { ActionMeta, FormatOptionLabelMeta, AsyncSelect as ReactSearch } from "chakra-react-select";
 import { GroupBase, OptionsOrGroups } from "chakra-react-select";
 import { SizeProp, Variant } from "chakra-react-select/dist/types/types";
 
@@ -50,6 +50,9 @@ export type BaseProps<T> = {
 
   /** Variable to override the selected value of the component. Null resets the component and undefined  is ignored. When in use update value from the onChange function */
   value?: T | null;
+
+  /** Function for formatting the labels in the dropdown menu */
+  optionLabelFormatter?: (data: T, formatOptionLabelMeta: FormatOptionLabelMeta<T>) => ReactNode;
 };
 
 type WithMulti<T> = {
@@ -86,6 +89,7 @@ export const SearchAsync = <T extends unknown>({
   isDisabled,
   focusBorderColor,
   value,
+  optionLabelFormatter,
 }: SearchAsyncProps<T>) => {
   const noOptionsMessageDefault = ({ inputValue }: { inputValue: string }): ReactNode => {
     if (inputValue.replaceAll(/\s/g, "").length < 1) {
@@ -116,6 +120,7 @@ export const SearchAsync = <T extends unknown>({
         // Only use separator when there is a dropdownindicator
         ...(!dropdownIndicator ? { IndicatorSeparator: () => null } : {}),
       }}
+      formatOptionLabel={optionLabelFormatter}
       isClearable={isClearable}
       autoFocus={autoFocus}
       className={className ? className : ""}


### PR DESCRIPTION
# Beskrivelse

Legger til muligheten for å formattere options som vises i dropdownen til AsyncSearch-komponenten. Denne proppen ligger allerede på den underliggende chakra komponenten så mesteparten av jobben var bare å tilgjengeliggjøre denne. Lagde et nytt eksempel i storybook som viser hvordan man kan bruke den. 

![Screenshot 2024-04-02 at 13 32 13](https://github.com/kartverket/kvib/assets/49037552/400e60cd-8222-42bb-b704-44c7066fb562)

# Sjekkliste

- [x] Sjekket at komponenten matcher designet i Figma
- [x] Har fått design review med en designer
- [x] Sjekket universell utforming for komponenten. Se for eksempel:
  - https://www.magentaa11y.com/web/
  - https://a11y-101.com/development
  - https://www.a11yproject.com/checklist/#appearance
- [x] Denne PR-en inneholder en enkelt komponent
