### PR TITLE
BUG: Snarveier på velkomstsiden leder til feil adresse

### DIFF
--- a/apps/storybook/stories/introduksjon.mdx
+++ b/apps/storybook/stories/introduksjon.mdx
@@ -1,7 +1,6 @@
 import { Meta } from "@storybook/addon-docs";
 import { Banner } from "./documentation/utils/Banner";
-import { DocsHeading, DocsAnatomy, DocsContainer, DocsStory, Feedback } from "./templates";
-import { Text, Code, Box, Heading, SimpleGrid, Grid } from "@kvib/react/src/";
+import { SimpleGrid } from "@kvib/react/src/";
 import { IntroButton, IntroCardGrid } from "./documentation/utils/IntroButton";
 import * as IntroCards from "./documentation/utils/IntroCard";
 

--- a/apps/storybook/stories/introduksjon.mdx
+++ b/apps/storybook/stories/introduksjon.mdx
@@ -13,14 +13,14 @@ import * as IntroCards from "./documentation/utils/IntroCard";
 
 <IntroButton
   icon="assets/Grid.svg"
-  href="/?path=/docs/komponenter-komponentoversikt--docs"
+  href="/?path=/docs/oversikt-komponentoversikt--docs"
   title="Komponenter"
   description="Alle komponentene i designsystemet"
 />
 
 <IntroButton
   icon="assets/Palette.svg"
-  href="/?path=/docs/design-fundament-design-tokens--docs"
+  href="/?path=/docs/designfundament-farger--docs"
   title="Design tokens"
   description="Farger, breakpoints, spacing, etc."
 />

--- a/package-lock.json
+++ b/package-lock.json
@@ -28508,7 +28508,7 @@
     },
     "packages/react": {
       "name": "@kvib/react",
-      "version": "4.0.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",


### PR DESCRIPTION
Endret på href slik at knappene på oversiktsiden virket igjen. 
Design tokens ble delt opp til flere sider, så jeg valgte å peke mot fargetokens som en midlertidig løsning.