### PR TITLE
Fjerner aria-label for ikon på eksterne lenker

### DIFF
--- a/.changeset/grumpy-baboons-lay.md
+++ b/.changeset/grumpy-baboons-lay.md
@@ -2,4 +2,4 @@
 "@kvib/react": minor
 ---
 
-Option for hiding aria on external link icon
+Remove aria-label for launch icon on external links

--- a/apps/storybook/stories/components/navigasjon/link/Link.stories.tsx
+++ b/apps/storybook/stories/components/navigasjon/link/Link.stories.tsx
@@ -34,11 +34,6 @@ const meta: Meta<typeof KvibLink> = {
       },
       control: "text",
     },
-    iconAriaIsHidden: {
-      table: { type: { summary: "boolean" } },
-      control: "boolean",
-      defaultValue: { summary: false },
-    },
   },
 };
 

--- a/packages/react/src/link/Link.tsx
+++ b/packages/react/src/link/Link.tsx
@@ -5,9 +5,6 @@ export type LinkProps = Omit<ChakraLinkProps, "colorScheme" | "variant"> & {
    * @default green
    */
   colorScheme?: "green" | "blue";
-
-  /**Decides whether a screen reader will vocalize the icon name or not */
-  iconAriaIsHidden?: boolean;
 };
 
 /** Link to different sites or parts of site
@@ -23,9 +20,8 @@ export const Link = forwardRef<LinkProps, "a">(({ children, ...props }, ref) => 
         <span
           className="material-symbols-rounded"
           style={{ fontSize: "18px", verticalAlign: "middle", marginLeft: "4px" }}
-          aria-label="launch-ikon"
-          aria-hidden={props.iconAriaIsHidden}
           role="link"
+          aria-hidden
         >
           launch
         </span>


### PR DESCRIPTION
# Beskrivelse
Edit: Har konkludert med at det er godkjent ift. WCAG-kravene å sløyfe hele aria-labelen til ikonet for eksterne lenker så lenge man inkluderer en label som sier noe om at lenken er ekstern. Da unngår man at det som leses opp på `Link`-komponenten får lagt til "launch_ikon" på slutten som uansett bare skaper støy for brukere med skjermleserbehov.

~~For å unngå at en skjermleser leser opp en `<Link isExternal href="https://chakra-ui.com/docs/components">Dette er en lenke</Link>` som "Dette er en lenkelaunch_ikon" har jeg lagt til muligheten for å skru av aria-opplesningen av ikonnavnet. Denne brukes ved å sette prop-en `iconAriaIsHidden` på `<Link />`-komponenten.~~

# Sjekkliste

<!-- Sjekk av disse punktene for hver endring -->

- [x] Sjekket at komponenten matcher designet i Figma
- [x] Har fått design review med en designer
- [x] Sjekket universell utforming for komponenten. Se for eksempel:
  - https://www.magentaa11y.com/web/
  - https://a11y-101.com/development
  - https://www.a11yproject.com/checklist/#appearance
- [x] Denne PR-en inneholder en enkelt komponent


~~Utvidet komponenten slik at man aktivt må gå inn selv og si at aria ikke skal leses opp, men jeg mener egentlig at standarden kanskje burde være at dette ikonet ikke leses opp i det hele tatt? Spesielt siden dette ikonet kun er tatt med for estetikk og ikke gir noe direkte funksjonalitet kan man nok fjerne det og heller inkludere "ekstern lenke" eller noe sånt på selve lenken?~~