### PR TITLE
KOMP-467 Mulighet for bruk av ref på SearchAsync

### DIFF
--- a/.changeset/cold-guests-thank.md
+++ b/.changeset/cold-guests-thank.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+Legg til mulighet for bruk av ref på SearchAsync

--- a/apps/storybook/stories/components/search/search-async/SearchAsync.mdx
+++ b/apps/storybook/stories/components/search/search-async/SearchAsync.mdx
@@ -190,24 +190,24 @@ const Component = (isOpen: boolean) => {
   const searchRef = useRef<SelectInstance<number, boolean, GroupBase<number>>>(null);
   const [currentValue, setCurrentValue] = useState<number | null>(-1);
 
-    useEffect(() => {
-      if (isOpen && searchRef.current != null) {
-        searchRef.current.focus();
-      }
-    }, [isOpen]);
+  useEffect(() => {
+    if (isOpen && searchRef.current != null) {
+      searchRef.current.focus();
+    }
+  }, [isOpen]);
 
-    return (
-      <SearchAsync
-        onChange={(number: number | null) => {
-          setCurrentValue(number);
-        }}
-        value={currentValue}
-        loadOptions={() => {
-          return [1, 2, 3];
-        }}
-        ref={searchRef}
-      />
-    );
+  return (
+    <SearchAsync
+      onChange={(number: number | null) => {
+        setCurrentValue(number);
+      }}
+      value={currentValue}
+      loadOptions={() => {
+        return [1, 2, 3];
+      }}
+      ref={searchRef}
+    />
+  );
 };`}
 dark
 />

--- a/apps/storybook/stories/components/search/search-async/SearchAsync.mdx
+++ b/apps/storybook/stories/components/search/search-async/SearchAsync.mdx
@@ -183,11 +183,11 @@ I dette eksempelet så setter vi opp en enkel SearchAsync, hvor vi ønsker at ko
 
 <Source
   code={`
-import { SearchAsync, SelectInstance, GroupBase } from "@kvib/react";
+import { SearchAsync, SearchAsyncElement } from "@kvib/react";
 import { useEffect, useRef, useState } from "react";
 
 const Component = (isOpen: boolean) => {
-  const searchRef = useRef<SelectInstance<number, boolean, GroupBase<number>>>(null);
+  const searchRef = useRef<SearchAsyncElement<number>>(null);
   const [currentValue, setCurrentValue] = useState<number | null>(-1);
 
   useEffect(() => {

--- a/apps/storybook/stories/components/search/search-async/SearchAsync.mdx
+++ b/apps/storybook/stories/components/search/search-async/SearchAsync.mdx
@@ -173,6 +173,51 @@ const noOptionsMessage = ({ inputValue }: { inputValue: string }) => {
 
 </DocsContainer>
 
+<DocsHeading light>Bruk av ref</DocsHeading>
+<DocsContainer>
+  Ref kan brukes dersom det er nødvendig å interagere med selve select elementet. Merk at dette ikke er et standard{" "}
+  <Code>HTMLSelectElement</Code>, men en instans av en klasse fra en av pakkene KVIB bruker. Ettersom ref er av en litt
+  spesiell type så viser vi et eksempel på bruk her.
+
+I dette eksempelet så setter vi opp en enkel SearchAsync, hvor vi ønsker at komponenten skal legge fokus på SearchAsync input-feltet når komponenten er åpen:
+
+<Source
+  code={`
+import { SearchAsync, SelectInstance, GroupBase } from "@kvib/react";
+import { useEffect, useRef, useState } from "react";
+
+const Component = (isOpen: boolean) => {
+const searchRef = useRef<SelectInstance<number, boolean, GroupBase<number>>>(null);
+const [currentValue, setCurrentValue] = useState<number | null>(-1);
+
+    useEffect(() => {
+      if (isOpen && searchRef.current != null) {
+        searchRef.current.focus();
+      }
+    }, [isOpen]);
+
+    return (
+      <SearchAsync
+        onChange={(number: number | null) => {
+          setCurrentValue(number);
+        }}
+        value={currentValue}
+        loadOptions={() => {
+          return [1, 2, 3];
+        }}
+        ref={searchRef}
+      />
+    );
+
+};`}
+dark
+/>
+
+Legg merke til her at `useRef` sin type bruker genericen T som også blir brukt et par andre steder i props.
+Så når du skal sette typen for `useRef` må du være bevisst på hvilken type du bruker som options for resten av komponenten.
+
+</DocsContainer>
+
 <DocsHeading light>Retningslinjer</DocsHeading>
 
 <DocsContainer>
@@ -191,19 +236,19 @@ Det er anbefalt å bruke `<form>` rundt SearchAsync dersom du skal bruke det val
 <Source
   code={`
   <form onSubmit={handleSubmit}>
-      <FormControl>
-        <FormLabel htmlFor="async-search">Søk etter frukt</FormLabel>
-          <SearchAsync
-            loadOptions={mockLoadOptions}
-            onChange={handleChange}
-            placeholder="Søk etter frukt..."
-            isMulti={false}
-          />
-        <Button mt={4} colorScheme="blue" type="submit">
-          Send
-        </Button>
-      </FormControl>
-    </form>`}
+    <FormControl>
+      <FormLabel htmlFor="async-search">Søk etter frukt</FormLabel>
+        <SearchAsync
+          loadOptions={mockLoadOptions}
+          onChange={handleChange}
+          placeholder="Søk etter frukt..."
+          isMulti={false}
+        />
+      <Button mt={4} colorScheme="blue" type="submit">
+        Send
+      </Button>
+    </FormControl>
+  </form>`}
   dark
 />
 

--- a/apps/storybook/stories/components/search/search-async/SearchAsync.mdx
+++ b/apps/storybook/stories/components/search/search-async/SearchAsync.mdx
@@ -187,8 +187,8 @@ import { SearchAsync, SelectInstance, GroupBase } from "@kvib/react";
 import { useEffect, useRef, useState } from "react";
 
 const Component = (isOpen: boolean) => {
-const searchRef = useRef<SelectInstance<number, boolean, GroupBase<number>>>(null);
-const [currentValue, setCurrentValue] = useState<number | null>(-1);
+  const searchRef = useRef<SelectInstance<number, boolean, GroupBase<number>>>(null);
+  const [currentValue, setCurrentValue] = useState<number | null>(-1);
 
     useEffect(() => {
       if (isOpen && searchRef.current != null) {
@@ -208,7 +208,6 @@ const [currentValue, setCurrentValue] = useState<number | null>(-1);
         ref={searchRef}
       />
     );
-
 };`}
 dark
 />

--- a/apps/storybook/stories/components/search/search-async/SearchAsync.stories.tsx
+++ b/apps/storybook/stories/components/search/search-async/SearchAsync.stories.tsx
@@ -8,7 +8,6 @@ import {
   Badge,
 } from "@kvib/react/src";
 import { Meta, StoryObj } from "@storybook/react";
-import { FormatOptionLabelMeta } from "chakra-react-select";
 
 const meta: Meta<typeof KvibSearchAsync> = {
   title: "Søk/SearchAsync",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28508,7 +28508,7 @@
     },
     "packages/react": {
       "name": "@kvib/react",
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^2.8.2",

--- a/packages/react/src/search-async/SearchAsync.tsx
+++ b/packages/react/src/search-async/SearchAsync.tsx
@@ -11,7 +11,7 @@ import {
 } from "chakra-react-select";
 import { SizeProp, Variant } from "chakra-react-select/dist/types/types";
 
-export type { ActionMeta, SelectInstance, GroupBase } from "chakra-react-select";
+export type SearchAsyncElement<T> = SelectInstance<T, boolean, GroupBase<T>>;
 
 // Props interface is defined with a generic T to allow flexibility in the data type of options.
 export type BaseProps<T> = {
@@ -66,7 +66,7 @@ export type BaseProps<T> = {
   /** Reference to the instance of the select element. Note that this is not a default HTMLSelectElement, but a class from the react-select package. As such, the
    * type must be imported from KVIB.
    */
-  ref?: Ref<SelectInstance<T, boolean, GroupBase<T>>>;
+  ref?: Ref<SearchAsyncElement<T>>;
 };
 
 type WithMulti<T> = {

--- a/packages/react/src/search-async/index.tsx
+++ b/packages/react/src/search-async/index.tsx
@@ -1,1 +1,2 @@
 export * from "./SearchAsync";
+export type { ActionMeta } from "chakra-react-select";

--- a/packages/react/src/search-async/index.tsx
+++ b/packages/react/src/search-async/index.tsx
@@ -1,2 +1,1 @@
 export * from "./SearchAsync";
-export type { ActionMeta } from "chakra-react-select";


### PR DESCRIPTION
# Beskrivelse

Vi hadde behov for å sette focus på SearchAsync input feltet, så trenger refen. Legger til dette som prop til SearchAsync.

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->

# Sjekkliste

<!-- Sjekk av disse punktene for hver endring. Disse utgjør et minimum av sjekker som skal være gjennomført før PR-en merges. For mer informasjon om hvordan du kan bidra med kode til designbiblioteket, se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-hurtigveiledning--docs-->

- [x] Alle tester har kjørt, og er grønne.
- [x] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [ ] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [x] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [x] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [x] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
