### PR TITLE
Kvd 470 farge loading toast

### DIFF
--- a/.changeset/dull-kiwis-float.md
+++ b/.changeset/dull-kiwis-float.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+Endret farge på "loading"-toast slik at den matcher farge på "info"

--- a/packages/react/src/theme/components/alert.ts
+++ b/packages/react/src/theme/components/alert.ts
@@ -54,7 +54,7 @@ const variantSolid = defineStyle((props) => {
       },
     };
   }
-  if (s === "info") {
+  if (s === "info" || s === "loading") {
     return {
       title: {
         color: colors.white,

--- a/packages/react/src/theme/components/alert.ts
+++ b/packages/react/src/theme/components/alert.ts
@@ -54,7 +54,7 @@ const variantSolid = defineStyle((props) => {
       },
     };
   }
-  if (s === "info" || s === "loading") {
+  if (s === "info") {
     return {
       title: {
         color: colors.white,


### PR DESCRIPTION
# Beskrivelse

Loading status på toast/alert har nå riktig blåfarge
Før:
![image](https://github.com/kartverket/kvib/assets/122277136/405a4b73-c002-4280-b82b-760bb5a5e289)

Etter:
![image](https://github.com/kartverket/kvib/assets/122277136/ef62a782-8edd-4b1a-9ca8-63f2101c2cb6)

# Sjekkliste

<!-- Sjekk av disse punktene for hver endring. Disse utgjør et minimum av sjekker som skal være gjennomført før PR-en merges. For mer informasjon om hvordan du kan bidra med kode til designbiblioteket, se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-hurtigveiledning--docs-->

- [x] Alle tester har kjørt, og er grønne.
- [ ] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [x] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [x] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [x] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [ ] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
