### PR TITLE
Ikoner i Storybook-dokumentasjon

### DIFF
--- a/apps/storybook/.storybook/docs-root.css
+++ b/apps/storybook/.storybook/docs-root.css
@@ -26,10 +26,6 @@ div[role="main"] > :first-child {
   transition: box-shadow 0.2s ease;
 }
 
-.docs-icon {
-  font-family: "Material Symbols Rounded" !important;
-}
-
 /* Sidebar */
 /* .container.sidebar-container {
 } */
@@ -242,4 +238,8 @@ input[type="range"]::-webkit-slider-thumb:active {
   .frontpage-banner {
     background-image: none !important;
   }
+}
+
+.material-symbols-rounded {
+  font-family: "Material Symbols Rounded" !important;
 }

--- a/apps/storybook/stories/documentation/utils/Components.tsx
+++ b/apps/storybook/stories/documentation/utils/Components.tsx
@@ -79,7 +79,7 @@ const ComponentCard = ({
           gap="4px"
           textDecoration="none"
         >
-          Gå til {title} <Icon icon="arrow_forward" className="docs-icon" weight={300} size={18} aria-hidden />
+          Gå til {title} <Icon icon="arrow_forward" weight={300} size={18} aria-hidden />
         </Link>
       </Stack>
     </Card>

--- a/apps/storybook/stories/documentation/utils/IntroButton.tsx
+++ b/apps/storybook/stories/documentation/utils/IntroButton.tsx
@@ -25,7 +25,7 @@ export const IntroButton = ({
         <Text fontSize="lg" as="b" color="green.500">
           {title}{" "}
           <Box sx={{ display: isExternal ? "inline-block" : "none" }}>
-            <Icon icon="open_in_new" className="docs-icon" size={18} weight={400} />
+            <Icon icon="open_in_new" size={18} weight={400} />
           </Box>
         </Text>
       </Flex>


### PR DESCRIPTION

# Beskrivelse

Endret på styling slik at man ikke må legge til en egen klasse på ikoner når man jobber i storybook.


# Sjekkliste

- [x] Alle tester har kjørt, og er grønne.
- [ ] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [x] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [x] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [ ] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [ ] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
