### PR TITLE
Added linkProps as a prop to be able to change the functionality for the link within the header.

### DIFF
--- a/.changeset/khaki-cooks-sit.md
+++ b/.changeset/khaki-cooks-sit.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Added linkProps as a prop to be able to change the functionality for the link within the header.

--- a/apps/storybook/stories/components/sideelementer/header/Header.stories.tsx
+++ b/apps/storybook/stories/components/sideelementer/header/Header.stories.tsx
@@ -39,9 +39,13 @@ const meta: Meta<typeof KvibHeader> = {
     logoLink: {
       table: {
         type: { summary: "string" },
-        defaulValue: { summary: "/" },
+        defaultValue: { summary: "/" },
       },
       control: "text",
+    },
+    logoLinkProps: {
+      table: { summary: "object" },
+      defaultValue: { summary: undefined },
     },
     showMenuButton: {
       table: {

--- a/packages/react/src/header/Header.tsx
+++ b/packages/react/src/header/Header.tsx
@@ -9,6 +9,7 @@ import {
   Collapse,
   defaultKvibTheme,
   Link,
+  LinkProps,
 } from "@kvib/react/src";
 
 type HeaderProps = {
@@ -16,6 +17,8 @@ type HeaderProps = {
   justifyContent?: "space-between" | "center" | "start";
   /** Href for logo link */
   logoLink?: string;
+  /** As for logo link */
+  logoLinkProps?: Omit<LinkProps, "href">;
   /** Alt Text for logo */
   logoAltText?: string;
   /** Children to be displayed in the header. */
@@ -39,6 +42,7 @@ export const Header = (props: HeaderProps) => {
   const {
     justifyContent = "space-between",
     logoLink = "/",
+    logoLinkProps,
     logoAltText,
     children,
     showMenuButton = false,
@@ -73,7 +77,7 @@ export const Header = (props: HeaderProps) => {
         justifyContent={justify}
         gap={gap}
       >
-        <Link href={logoLink} isExternal={false}>
+        <Link href={logoLink} isExternal={false} {...logoLinkProps}>
           <Logo
             label={logoAltText}
             variant={logoVariant}


### PR DESCRIPTION
# Beskrivelse
Adding another prop to the `Header` component to be able to change behaviour of the link.
Found that the `isExternal={false}` was not enough for our use case.
We have a create-react-app project with tanstack-query and with our setup the link is still behaving as an external link, reseting the browser state which prevents us from keeping our caching. 
I have not tried multiple setups so I can't tell how it is for other systems like remix or next.

By using the `as` property we can remain within our context. By doing this we have the ability to use that property.


# Sjekkliste

<!-- Sjekk av disse punktene for hver endring. Disse utgjør et minimum av sjekker som skal være gjennomført før PR-en merges. For mer informasjon om hvordan du kan bidra med kode til designbiblioteket, se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-hurtigveiledning--docs-->

- [ ] Alle tester har kjørt, og er grønne.
- [ ] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [ ] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [ ] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [ ] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [ ] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
