### PR TITLE
Endrer utdaterte URL-er i Slack-varsling

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -31,7 +31,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":mega: *En ny versjon av <https://kartverket.github.io/kvib|Kartverkets Designsystem> har blitt publisert!* :mega: \n\n Nyeste versjon: <https://kartverket.github.io/kvib/?path=/docs/changelog--docs|${{ steps.set_message.outputs.version }}>."
+                    "text": ":mega: *En ny versjon av <https://design.kartverket.no|Kartverkets Designsystem> har blitt publisert!* :mega: \n\n Nyeste versjon: <https://design.kartverket.no/?path=/docs/oversikt-endringslogg--docs|${{ steps.set_message.outputs.version }}>."
                   }
                 }
               ]


### PR DESCRIPTION
# Beskrivelse

URL-ene som postes i `#designsystem-status`-kanalen er utdaterte, og den siste lenken der fører til en side med feilmelding i Storybook. Endrer URL-ene til å matche design.kartverket.no og endringsloggen der.
<img width="733" alt="image" src="https://github.com/user-attachments/assets/68e3f3ef-2847-40f1-83b8-db04b6cf4ac3">

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/72df30fe-e2ee-4cc2-ab38-2d4b57e03a4f">


# Sjekkliste

<!-- Sjekk av disse punktene for hver endring. Disse utgjør et minimum av sjekker som skal være gjennomført før PR-en merges. For mer informasjon om hvordan du kan bidra med kode til designbiblioteket, se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-hurtigveiledning--docs-->

- [ ] Alle tester har kjørt, og er grønne.
- [ ] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [ ] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [ ] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [ ] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [ ] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
