### PR TITLE
Fjerner kort fra landingsside

### DIFF
--- a/apps/storybook/stories/documentation/utils/IntroCard.tsx
+++ b/apps/storybook/stories/documentation/utils/IntroCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Text, Link, Flex, Box, Stack } from "@kvib/react/src";
+import { Box, Card, Flex, Link, Stack, Text } from "@kvib/react/src";
 
 export const StarCard = () => {
   return (
@@ -92,7 +92,7 @@ export const LinksCard = () => {
     </IntroCard>
   );
 };
-
+/*
 export const SurveyCard = () => {
   return (
     <IntroCard>
@@ -121,7 +121,7 @@ export const SurveyCard = () => {
       </Element>
     </IntroCard>
   );
-};
+}; */
 
 export const FeedbackCard = () => {
   return (

--- a/apps/storybook/stories/introduksjon.mdx
+++ b/apps/storybook/stories/introduksjon.mdx
@@ -10,12 +10,13 @@ import * as IntroCards from "./documentation/utils/IntroCard";
 
 <Box>
 <IntroCardGrid>
-<IntroButton
+
+{/* <IntroButton
   icon="grid_on"
   href="/?path=/docs/oversikt-komponentoversikt--docs"
   title="Komponenter"
   description="Et bibliotek med komponenter, forhåndsvisninger, kildekode og retningslinjer for bruk."
-/>
+/> */}
 
 <IntroButton
   icon="palette"
@@ -30,9 +31,6 @@ import * as IntroCards from "./documentation/utils/IntroCard";
   title="Ikoner"
   description="En oversikt over ikonbiblioteket som Kartverket bruker."
 />
-</IntroCardGrid>
-
-<IntroCardGrid>
 <IntroButton
   icon="grid_on"
   href="https://www.kartverket.no/om-kartverket/kartverkets-identitet"
@@ -40,6 +38,9 @@ import * as IntroCards from "./documentation/utils/IntroCard";
   isExternal
   description="Bli kjent med Kartverket sin merkevare. Veiledning og retningslinjer til deg som skal ta identiteten i bruk."
 />
+</IntroCardGrid>
+
+<IntroCardGrid>
 
 <IntroButton
   icon="palette"
@@ -65,7 +66,7 @@ import * as IntroCards from "./documentation/utils/IntroCard";
 
 <IntroCards.LinksCard />
 
-<IntroCards.SurveyCard />
+{/* <IntroCards.SurveyCard /> */}
 
 <IntroCards.FeedbackCard />
 


### PR DESCRIPTION
# Beskrivelse

Inntil videre blir lenken til komponentoversikten fjernet ettersom at denne ikke virker akkurat nå. Informasjon om spørreskjema fjernes også til fordel for nytt skjema som legges ut på Slack.

# Sjekkliste

<!-- Sjekk av disse punktene for hver endring. Disse utgjør et minimum av sjekker som skal være gjennomført før PR-en merges. For mer informasjon om hvordan du kan bidra med kode til designbiblioteket, se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-hurtigveiledning--docs>

- [ ] Alle tester har kjørt, og er grønne.
- [ ] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [ ] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [ ] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [ ] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [ ] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
