### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organization: IT
 product: Designsystemet
 repo_types: [PublicClient,Library]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,37 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "kvib"
+  tags:
+  - "public"
+spec:
+  type: "website"
+  lifecycle: "production"
+  owner: "designsystem"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_kvib"
+  title: "Security Champion kvib"
+spec:
+  type: "security_champion"
+  parent: "it_security_champions"
+  members:
+  - "nilben"
+  children:
+  - "resource:kvib"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "kvib"
+  links:
+  - url: "https://github.com/kartverket/kvib"
+    title: "kvib på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_kvib"
+  dependencyOf:
+  - "component:kvib"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.