### PR TITLE
Justerer track-farger fra 400 til 300 på Switch og Slider

### DIFF
--- a/.changeset/pretty-melons-beam.md
+++ b/.changeset/pretty-melons-beam.md
@@ -2,4 +2,4 @@
 "@kvib/react": minor
 ---
 
-Justerer grå bakgrunsfarge på Slider og Switch fra 500 til 300
+Justerer grå track-bakgrunnsfarge på Slider og Switch fra 500 til 300

--- a/.changeset/pretty-melons-beam.md
+++ b/.changeset/pretty-melons-beam.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+Justerer grå bakgrunsfarge på Slider og Switch fra 500 til 300

--- a/packages/react/src/theme/components/slider.ts
+++ b/packages/react/src/theme/components/slider.ts
@@ -3,7 +3,7 @@ import { defineStyle, defineStyleConfig } from "@chakra-ui/react";
 const baseStyle = defineStyle((props) => {
   return {
     track: {
-      bg: "gray.400",
+      bg: "gray.300",
     },
     thumb: {
       borderWidth: "2px",

--- a/packages/react/src/theme/components/switch.ts
+++ b/packages/react/src/theme/components/switch.ts
@@ -3,7 +3,7 @@ import { defineStyleConfig } from "@chakra-ui/react";
 export const switchTheme = defineStyleConfig({
   baseStyle: ({ colorScheme }) => ({
     track: {
-      bg: "gray.400", // Border color when unchecked
+      bg: "gray.300", // Border color when unchecked
       _checked: {
         bg: `${colorScheme}.500`,
       },


### PR DESCRIPTION
# Beskrivelse
Track-fargen på `Slider` og `Switch` er litt i det mørkeste laget. Etter innspill fra @erlendst jekkes disse grå bakgrunnsfargene fra `gray.400` til den litt lysere `gray.300`-fargen.

Før:
![image](https://github.com/user-attachments/assets/47e805ee-e566-40b7-a7eb-ce97c273bb2d)

Etter:
![image](https://github.com/user-attachments/assets/4e94d41d-f03b-43aa-af3a-eb87fd9ceadc)
