### PR TITLE
Retter feil som førte til tap av fokus i Search

### DIFF
--- a/.changeset/wise-spiders-rest.md
+++ b/.changeset/wise-spiders-rest.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Retter feil som førte til tap av fokus i Search

--- a/packages/react/src/search/Search.tsx
+++ b/packages/react/src/search/Search.tsx
@@ -5,8 +5,8 @@ import {
   InputProps as ChakraInputProps,
   InputRightElement as ChakraInputRightElement,
   forwardRef,
-  useDimensions,
 } from "@chakra-ui/react";
+import { useSize } from "@chakra-ui/react-use-size";
 import { useRef } from "react";
 import { Button, IconButton } from "../button";
 
@@ -41,7 +41,7 @@ export const Search = forwardRef<SearchProps, "input">(
   ) => {
     // Used to calculate width of button if no buttonWidth is given and there is text in the button
     const elementRef = useRef(null);
-    const dimensions = useDimensions(elementRef);
+    const dimensions = useSize(elementRef);
 
     // Use IconButton when there is no text in the button
     const RenderButton = ({ position }: RenderProps) => {
@@ -73,7 +73,7 @@ export const Search = forwardRef<SearchProps, "input">(
     const inputPadding = buttonWidth
       ? `calc(${buttonWidth} + 0.5rem)`
       : buttonText && dimensions
-        ? `calc(${dimensions.borderBox.width}px + 0.5rem)`
+        ? `calc(${dimensions.width}px + 0.5rem)`
         : "3rem";
 
     return (

--- a/packages/react/src/search/Search.tsx
+++ b/packages/react/src/search/Search.tsx
@@ -1,14 +1,14 @@
 import {
   Input as ChakraInput,
-  InputProps as ChakraInputProps,
-  forwardRef,
   InputGroup as ChakraInputGroup,
   InputLeftElement as ChakraInputLeftElement,
+  InputProps as ChakraInputProps,
   InputRightElement as ChakraInputRightElement,
+  forwardRef,
   useDimensions,
 } from "@chakra-ui/react";
-import { IconButton, Button } from "../button";
 import { useRef } from "react";
+import { Button, IconButton } from "../button";
 
 export type SearchProps = Omit<ChakraInputProps, "isRequired" | "colorScheme"> & {
   searchButton?: "left" | "right" | "none";
@@ -76,7 +76,7 @@ export const Search = forwardRef<SearchProps, "input">(
         ? `calc(${dimensions.borderBox.width}px + 0.5rem)`
         : "3rem";
 
-    const RenderInputGroup = () => (
+    return (
       <ChakraInputGroup size={size} width={props.width}>
         <ChakraInput
           {...props}
@@ -101,7 +101,5 @@ export const Search = forwardRef<SearchProps, "input">(
         )}
       </ChakraInputGroup>
     );
-
-    return <RenderInputGroup />;
   },
 );


### PR DESCRIPTION
Etter gode innspill fra @perzonas og @joonerik droppes `RenderInputGroup` som wrappet rundt inputtgruppen i en arrow function siden dette tegnet opp komponenten på nytt og på nytt.