### PR TITLE
Oppdaterer dokumentasjon for Modal og AlertDialog

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,10 +14,6 @@ concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
     runs-on: ubuntu-20.04
-    permissions:
-      contents: write
-      pull-requests: write
-      deployments: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "test-storybook",
     "dev": "storybook dev -p 6006 --no-open",
     "build": "storybook build",
     "build-storybook": "storybook build",

--- a/apps/storybook/stories/components/overlay/alert-dialog/AlertDialog.mdx
+++ b/apps/storybook/stories/components/overlay/alert-dialog/AlertDialog.mdx
@@ -1,8 +1,7 @@
-import { Meta, Canvas, Story, Controls, Source } from "@storybook/blocks";
-import * as AlertDialogStories from "./AlertDialog.stories";
 import { Card, CardBody } from "@kvib/react/src";
-import * as AlertDialogStrings from "./srcStrings.ts";
-import { DocsHeading, DocsAnatomy, DocsContainer, DocsStory, Feedback } from "../../../templates";
+import { Canvas, Controls, Meta, Source, Story } from "@storybook/blocks";
+import { DocsAnatomy, DocsContainer, DocsHeading, DocsStory, Feedback } from "../../../templates";
+import * as AlertDialogStories from "./AlertDialog.stories";
 
 <Meta of={AlertDialogStories} />
 
@@ -12,7 +11,15 @@ import { DocsHeading, DocsAnatomy, DocsContainer, DocsStory, Feedback } from "..
 
 AlertDialog er et komponent som brukes til å avbryte brukeren med en bekreftelesesdialog.
 
-```jsx
+<Canvas of={AlertDialogStories.AlertDialog} />
+
+<Feedback component="AlertDialog" />
+
+
+## Slik bruker du `AlertDialog`
+Alert Dialog består av flere komponenter som kan brukes sammen for å lage en dialog. Disse komponentene er `AlertDialog`, `AlertDialogOverlay`, `AlertDialogContent`, `AlertDialogHeader`, `AlertDialogFooter`, `AlertDialogBody` og `AlertDialogCloseButton` og importeres på følgende måte:
+
+```tsx
 import {
   AlertDialog,
   AlertDialogBody,
@@ -23,27 +30,19 @@ import {
   AlertDialogCloseButton,
 } from "@kvib/react";
 ```
+<br/><br/>
 
-<Feedback component="AlertDialog" />
+### Bruk av Alert Dialog med sentrert posisjon
+Alert Dialog kan plasseres vertikalt og horisontalt sentrert i forhold til skjermen. Dette gjør man med å sende inn `isCentered`-propen til `AlertDialog`-komponenten.
+<Canvas of={AlertDialogStories.AlertDialogCentered} />
 
-## Endring av transition
 
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={AlertDialogStories.AlertDialogTransition} />
-  </CardBody>
-</Card>
 
-<Source code={AlertDialogStrings.AlertDialogTransitionString} dark />
+### Bruk av Alert Dialog med animert overgang
+Modaler støtter overganger som animerer åpningen og lukkingen av modalen. Disse overgangene kan endres ved å sende inn `motionPreset`-propen til `Modal`-komponenten, og støtter verdiene `slideInBottom`, `slideInRight`, `scale` og `none`.
+<Canvas of={AlertDialogStories.AlertDialogTransition} />
 
-<DocsHeading light children="Props" />
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={AlertDialogStories.AlertDialog} />
-  </CardBody>
-</Card>
-
-<Source code={AlertDialogStrings.AlertDialogString} dark />
-<Controls of={AlertDialogStories.AlertDialog} />
+## Props
+<Controls of={AlertDialogStories.AlertDialog}/>
 
 </DocsContainer>

--- a/apps/storybook/stories/components/overlay/alert-dialog/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/components/overlay/alert-dialog/AlertDialog.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from "@kvib/react/src";
 import { Meta, StoryObj } from "@storybook/react";
 import { useRef } from "react";
+import { AlertDialogCenteredString, AlertDialogString, AlertDialogTransitionString } from "./srcStrings";
 
 const meta: Meta<typeof KvibAlertDialog> = {
   title: "Overlay/Alert Dialog",
@@ -18,7 +19,7 @@ const meta: Meta<typeof KvibAlertDialog> = {
   parameters: {
     docs: {
       story: { inline: true },
-      canvas: { sourceState: "shown" },
+      canvas: { sourceState: "hidden" },
     },
   },
   argTypes: {
@@ -204,30 +205,31 @@ const meta: Meta<typeof KvibAlertDialog> = {
 export default meta;
 type Story = StoryObj<typeof KvibAlertDialog>;
 
-export const AlertDialogExample = ({ ...args }) => {
+const AlertDialogExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const cancelRef = useRef<HTMLButtonElement>(null);
 
   return (
     <>
       <Button colorScheme="red" onClick={onOpen}>
-        Slett
+        Åpne alert dialog
       </Button>
 
       <KvibAlertDialog {...args} isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={onClose}>
         <AlertDialogOverlay>
           <AlertDialogContent>
             <AlertDialogHeader fontSize="lg" fontWeight="bold">
-              Slett
+              Bekreft sletting
+              <AlertDialogCloseButton />
             </AlertDialogHeader>
 
-            <AlertDialogBody>Er du sikker? Du kan ikke angre senere.</AlertDialogBody>
+            <AlertDialogBody>Er du sikker på at du vil slette?</AlertDialogBody>
 
             <AlertDialogFooter>
-              <Button ref={cancelRef} onClick={onClose}>
+              <Button ref={cancelRef} onClick={onClose} variant="secondary" colorScheme="blue">
                 Avbryt
               </Button>
-              <Button colorScheme="red" onClick={onClose} ml={3}>
+              <Button onClick={onClose} ml={3} colorScheme="red">
                 Slett
               </Button>
             </AlertDialogFooter>
@@ -239,36 +241,49 @@ export const AlertDialogExample = ({ ...args }) => {
 };
 
 export const AlertDialog: Story = {
-  args: {},
-  render: (args) => <AlertDialogExample {...args} />,
+  render: args => <AlertDialogExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: AlertDialogString,
+      },
+    },
+  },
 };
 
-const TransitionExample = ({ ...args }) => {
+const AlertDialogTransitionExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const cancelRef = useRef<HTMLButtonElement>(null);
 
   return (
     <>
-      <Button onClick={onOpen}>Forkast endringer</Button>
+      <Button colorScheme="red" onClick={onOpen}>
+        Åpne alert dialog
+      </Button>
       <KvibAlertDialog
         {...args}
         motionPreset="slideInBottom"
         leastDestructiveRef={cancelRef}
         onClose={onClose}
         isOpen={isOpen}
-        isCentered
       >
         <AlertDialogOverlay />
         <AlertDialogContent>
-          <AlertDialogHeader>Forkast endringer?</AlertDialogHeader>
-          <AlertDialogCloseButton />
-          <AlertDialogBody>Er du sikker på at du vil forkaste notatene? 44 ord vil bli slettet.</AlertDialogBody>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            Bekreft sletting
+            <AlertDialogCloseButton />
+          </AlertDialogHeader>
+
+          <AlertDialogBody>Er du sikker på at du vil slette?</AlertDialogBody>
+
           <AlertDialogFooter>
-            <Button ref={cancelRef} onClick={onClose}>
-              Nei
+            <Button ref={cancelRef} onClick={onClose} variant="secondary" colorScheme="blue">
+              Avbryt
             </Button>
-            <Button colorScheme="red" ml={3}>
-              Ja
+            <Button onClick={onClose} ml={3} colorScheme="red">
+              Slett
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -278,6 +293,60 @@ const TransitionExample = ({ ...args }) => {
 };
 
 export const AlertDialogTransition: Story = {
-  args: {},
-  render: (args) => <TransitionExample {...args} />,
+  render: args => <AlertDialogTransitionExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: AlertDialogTransitionString,
+      },
+    },
+  },
+};
+
+const AlertDialogCenteredExample = ({ ...args }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <Button colorScheme="red" onClick={onOpen}>
+        Åpne alert dialog
+      </Button>
+      <KvibAlertDialog {...args} leastDestructiveRef={cancelRef} onClose={onClose} isOpen={isOpen} isCentered>
+        <AlertDialogOverlay />
+        <AlertDialogContent>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            Bekreft sletting
+            <AlertDialogCloseButton />
+          </AlertDialogHeader>
+
+          <AlertDialogBody>Er du sikker på at du vil slette?</AlertDialogBody>
+
+          <AlertDialogFooter>
+            <Button ref={cancelRef} onClick={onClose} variant="secondary" colorScheme="blue">
+              Avbryt
+            </Button>
+            <Button onClick={onClose} ml={3} colorScheme="red">
+              Slett
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </KvibAlertDialog>
+    </>
+  );
+};
+
+export const AlertDialogCentered: Story = {
+  render: args => <AlertDialogCenteredExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: AlertDialogCenteredString,
+      },
+    },
+  },
 };

--- a/apps/storybook/stories/components/overlay/alert-dialog/srcStrings.ts
+++ b/apps/storybook/stories/components/overlay/alert-dialog/srcStrings.ts
@@ -1,66 +1,110 @@
-export const AlertDialogString = `const AlertDialogExample = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const cancelRef = useRef<HTMLButtonElement>(null);
+export const AlertDialogString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+const cancelRef = useRef<HTMLButtonElement>(null);
 
-  return (
-    <>
-      <Button colorScheme="red" onClick={onOpen}>
-        Slett
-      </Button>
+return (
+  <>
+    <Button colorScheme="red" onClick={onOpen}>
+      Åpne alert dialog
+    </Button>
 
-      <AlertDialog  isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={onClose}>
-        <AlertDialogOverlay>
-          <AlertDialogContent>
-            <AlertDialogHeader fontSize="lg" fontWeight="bold">
-              Slett
-            </AlertDialogHeader>
-
-            <AlertDialogBody>Er du sikker? Du kan ikke angre senere.</AlertDialogBody>
-
-            <AlertDialogFooter>
-              <Button ref={cancelRef} onClick={onClose}>
-                Avbryt
-              </Button>
-              <Button colorScheme="red" onClick={onClose} ml={3}>
-                Slett
-              </Button>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialogOverlay>
-      </AlertDialog>
-    </>
-  );
-};`;
-
-export const AlertDialogTransitionString = `const TransitionExample = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const cancelRef = useRef<HTMLButtonElement>(null);
-
-  return (
-    <>
-      <Button onClick={onOpen}>Forkast endringer</Button>
-      <AlertDialog
-        motionPreset="slideInBottom"
-        leastDestructiveRef={cancelRef}
-        onClose={onClose}
-        isOpen={isOpen}
-        isCentered
-      >
-        <AlertDialogOverlay />
+    <AlertDialog isOpen={isOpen} leastDestructiveRef={cancelRef} onClose={onClose}>
+      <AlertDialogOverlay>
         <AlertDialogContent>
-          <AlertDialogHeader>Forkast endringer?</AlertDialogHeader>
-          <AlertDialogCloseButton />
-          <AlertDialogBody>Er du sikker på at du vil forkaste notatene? 44 ord vil bli slettet.</AlertDialogBody>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            Bekreft sletting
+            <AlertDialogCloseButton />
+          </AlertDialogHeader>
+
+          <AlertDialogBody>Er du sikker på at du vil slette?</AlertDialogBody>
+
           <AlertDialogFooter>
-            <Button ref={cancelRef} onClick={onClose}>
-              Nei
+            <Button ref={cancelRef} onClick={onClose} variant="secondary" colorScheme="blue">
+              Avbryt
             </Button>
-            <Button colorScheme="red" ml={3}>
-              Ja
+            <Button onClick={onClose} ml={3} colorScheme="red">
+              Slett
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
-      </AlertDialog>
-    </>
-  );
-};`;
+      </AlertDialogOverlay>
+    </AlertDialog>
+  </>
+);
+`;
+
+export const AlertDialogTransitionString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+const cancelRef = useRef<HTMLButtonElement>(null);
+
+return (
+  <>
+    <Button colorScheme="red" onClick={onOpen}>
+      Åpne alert dialog
+    </Button>
+    <AlertDialog
+      motionPreset="slideInBottom"
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+      isOpen={isOpen}
+    >
+      <AlertDialogOverlay />
+      <AlertDialogContent>
+        <AlertDialogHeader fontSize="lg" fontWeight="bold">
+          Bekreft sletting
+          <AlertDialogCloseButton />
+        </AlertDialogHeader>
+
+        <AlertDialogBody>Er du sikker på at du vil slette?</AlertDialogBody>
+
+        <AlertDialogFooter>
+          <Button ref={cancelRef} onClick={onClose} variant="secondary" colorScheme="blue">
+            Avbryt
+          </Button>
+          <Button onClick={onClose} ml={3} colorScheme="red">
+            Slett
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  </>
+);
+`;
+
+export const AlertDialogCenteredString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+const cancelRef = useRef<HTMLButtonElement>(null);
+
+return (
+  <>
+    <Button colorScheme="red" onClick={onOpen}>
+      Åpne alert dialog
+    </Button>
+    <AlertDialog
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+      isOpen={isOpen}
+      isCentered
+    >
+      <AlertDialogOverlay />
+      <AlertDialogContent>
+        <AlertDialogHeader fontSize="lg" fontWeight="bold">
+          Bekreft sletting
+          <AlertDialogCloseButton />
+        </AlertDialogHeader>
+
+        <AlertDialogBody>Er du sikker på at du vil slette?</AlertDialogBody>
+
+        <AlertDialogFooter>
+          <Button ref={cancelRef} onClick={onClose} variant="secondary" colorScheme="blue">
+            Avbryt
+          </Button>
+          <Button onClick={onClose} ml={3} colorScheme="red">
+            Slett
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  </>
+);
+`;

--- a/apps/storybook/stories/components/overlay/modal/Modal.mdx
+++ b/apps/storybook/stories/components/overlay/modal/Modal.mdx
@@ -1,8 +1,7 @@
-import { Meta, Canvas, Story, Controls, Source } from "@storybook/blocks";
+import { Canvas, Controls, Meta, Primary, Source, Story } from "@storybook/blocks";
+import { DocsAnatomy, DocsContainer, DocsHeading, DocsStory, Feedback } from "../../../templates";
 import * as ModalStories from "./Modal.stories";
-import { Card, CardBody } from "@kvib/react/src";
-import * as ModalStrings from "./srcStrings.ts";
-import { DocsHeading, DocsAnatomy, DocsContainer, DocsStory, Feedback } from "../../../templates";
+
 
 <Meta of={ModalStories} />
 
@@ -12,82 +11,43 @@ import { DocsHeading, DocsAnatomy, DocsContainer, DocsStory, Feedback } from "..
 
 En modal er en dialog som fokuserer brukerens oppmerksomhet på informasjonen i vinduet.
 
-## Ta i bruk
+<Canvas of={ModalStories.Modal} />
 
-```jsx
+## Slik bruker du `Modal`
+Modalen består av flere komponenter som kan brukes sammen for å lage en modal. Disse komponentene er `Modal`, `ModalOverlay`, `ModalContent`, `ModalHeader`, `ModalFooter`, `ModalBody` og `ModalCloseButton` og importeres på følgende måte:
+
+```tsx
 import { Modal, ModalOverlay, ModalContent, ModalHeader, ModalFooter, ModalBody, ModalCloseButton } from "@kvib/react";
 ```
+<br/><br/>
 
-<Feedback component="Modal" />
+### Bruk av modal med sentrert posisjon
+Modaler kan plasseres vertikalt og horisontalt sentrert i forhold til skjermen. Dette gjør man med å sende inn `isCentered`-propen til `Modal`-komponenten.
+<Canvas of={ModalStories.ModalCentered} />
 
-<DocsHeading light children="Block scrolling" />
 
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={ModalStories.ModalScrolling} />
-  </CardBody>
-</Card>
+### Bruk av modal med ulike størrelser
+Modaler kan ha ulike størrelser. Dette gjøres ved å sende inn `size`-propen til `Modal`-komponenten, og støtter verdiene `xs`, `sm`, `md`, `lg`, `xl` og `full`. Den siste verdien `full` gjør at modalen tar opp hele skjermen.
+<Canvas of={ModalStories.ModalSizes} />
 
-<Source code={ModalStrings.ModalScrollingString} dark />
 
-<DocsHeading light children="Fokus" />
+### Bruk av modal med animert overgang
+Modaler støtter overganger som animerer åpningen og lukkingen av modalen. Disse overgangene kan endres ved å sende inn `motionPreset`-propen til `Modal`-komponenten, og støtter verdiene `slideInBottom`, `slideInRight`, `scale` og `none`.
+<Canvas of={ModalStories.ModalTransition} />
 
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={ModalStories.ModalFocus} />
-  </CardBody>
-</Card>
 
-<Source code={ModalStrings.ModalFocusString} dark />
+### Bruk av modal med fokus
+Man kan rette fokus på spesifikke elementer når en modal åpnes eller lukkes. Dette gjøres ved å sende inn `initialFocusRef`- og `finalRef`-propsene.
+<Canvas of={ModalStories.ModalFocus} />
 
-<DocsHeading light children="Sentrering" />
+### Bruk av modal med egendefinert bakgrunn
+Modaler har en bakgrunn som dekker hele skjermen. Denne bakgrunnen kan endres ved å sende inn `overlayColor`-propen til `ModalOverlay`-komponenten.
+<Canvas of={ModalStories.ModalBackdrop} />
 
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={ModalStories.ModalCentered} />
-  </CardBody>
-</Card>
 
-<Source code={ModalStrings.ModalCenteredString} dark />
+### Bruk av modal med mulighet for å scrolle innholdet bak modalen
+Standarden er at modalen hindrer scrolling på innholdet bak modalen. Dette kan endres ved å sende inn `scrollBehavior`-propen til `Modal`-komponenten.
+<Canvas of={ModalStories.ModalScrolling} />
 
-<DocsHeading light children="Transition" />
-
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={ModalStories.ModalTransition} />
-  </CardBody>
-</Card>
-
-<Source code={ModalStrings.ModalTransitionString} dark />
-
-<DocsHeading light children="Størrelser" />
-
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={ModalStories.ModalSizes} />
-  </CardBody>
-</Card>
-
-<Source code={ModalStrings.ModalSizesString} dark />
-
-<DocsHeading light children="Bakteppe" />
-
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={ModalStories.ModalBackdrop} />
-  </CardBody>
-</Card>
-
-<Source code={ModalStrings.ModalBackdropString} dark />
-
-<DocsHeading light children="Props" />
-<Card variant="outline" borderRadius="0">
-  <CardBody>
-    <Story of={ModalStories.Modal} />
-  </CardBody>
-</Card>
-
-<Source code={ModalStrings.ModalString} dark />
-<Controls of={ModalStories.Modal} />
 
 </DocsContainer>

--- a/apps/storybook/stories/components/overlay/modal/Modal.mdx
+++ b/apps/storybook/stories/components/overlay/modal/Modal.mdx
@@ -13,6 +13,8 @@ En modal er en dialog som fokuserer brukerens oppmerksomhet på informasjonen i 
 
 <Canvas of={ModalStories.Modal} />
 
+<Feedback component="Modal" />
+
 ## Slik bruker du `Modal`
 Modalen består av flere komponenter som kan brukes sammen for å lage en modal. Disse komponentene er `Modal`, `ModalOverlay`, `ModalContent`, `ModalHeader`, `ModalFooter`, `ModalBody` og `ModalCloseButton` og importeres på følgende måte:
 
@@ -48,6 +50,9 @@ Modaler har en bakgrunn som dekker hele skjermen. Denne bakgrunnen kan endres ve
 ### Bruk av modal med mulighet for å scrolle innholdet bak modalen
 Standarden er at modalen hindrer scrolling på innholdet bak modalen. Dette kan endres ved å sende inn `scrollBehavior`-propen til `Modal`-komponenten.
 <Canvas of={ModalStories.ModalScrolling} />
+
+## Props
+<Controls of={ModalStories.Modal}/>
 
 
 </DocsContainer>

--- a/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
+++ b/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   FormControl,
   FormLabel,
@@ -227,18 +228,24 @@ export const ModalExample = ({ ...args }) => {
       <KvibModal {...args} isOpen={isOpen} onClose={onClose} colorScheme={args.colorScheme}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Historiske kart</ModalHeader>
+          <ModalHeader>Her er en modal</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            Vil du ha eit gammalt kart på hytteveggen? Historiske kart kan lastast ned og skrivast ut gratis. Ta ein
-            kikk i vårt arkiv!
+            Modaler må kun vises etter en brukerinteraksjon, og skal ikke avbryte brukeren på noe vis.
           </ModalBody>
 
-          <ModalFooter>
-            <Button colorScheme={args.colorScheme} variant="secondary" mr={3} onClick={onClose}>
-              Lukk
+          <ModalFooter justifyContent="space-between">
+            <Button onClick={onClose} variant="tertiary" colorScheme={args.colorScheme}>
+              Tertiær
             </Button>
-            <Button colorScheme={args.colorScheme}>Ta en kikk</Button>
+            <Box mr={3}>
+              <Button mr={3} onClick={onClose} variant="secondary" colorScheme={args.colorScheme}>
+                Sekundær
+              </Button>
+              <Button variant="primary" colorScheme={args.colorScheme}>
+                Primær
+              </Button>
+            </Box>
           </ModalFooter>
         </ModalContent>
       </KvibModal>
@@ -253,7 +260,6 @@ export const Modal: Story = {
 
 const ModalScrollingExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-
   return (
     <>
       <Button onClick={onOpen}>Åpne modal</Button>
@@ -261,18 +267,18 @@ const ModalScrollingExample = ({ ...args }) => {
       <KvibModal {...args} blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Modal tittel</ModalHeader>
+          <ModalHeader>Modal med scroll</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             <Text fontWeight="bold" mb="1rem">
-              Du kan scrolle i innholdet bak modalen
+              Her er en modal hvor du kan scrolle innholdet bak.
             </Text>
           </ModalBody>
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
-              Lukk
+            <Button mr={3} onClick={onClose} variant="secondary">
+              Avbryt
             </Button>
-            <Button variant="ghost">Annen handling</Button>
+            <Button variant="primary">Bekreft</Button>
           </ModalFooter>
         </ModalContent>
       </KvibModal>
@@ -301,25 +307,22 @@ const ModalFocusExample = ({ ...args }) => {
       <KvibModal {...args} initialFocusRef={initialRef} finalFocusRef={finalRef} isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Lag konto</ModalHeader>
+          <ModalHeader>Modal med skjema</ModalHeader>
           <ModalCloseButton />
           <ModalBody pb={6}>
             <FormControl>
-              <FormLabel>Fornavn</FormLabel>
+              <FormLabel>Navn</FormLabel>
               <Input ref={initialRef} placeholder="Fornavn" />
-            </FormControl>
-
-            <FormControl>
-              <FormLabel>Etternavn</FormLabel>
-              <Input placeholder="Etternavn" />
             </FormControl>
           </ModalBody>
 
           <ModalFooter>
-            <Button colorScheme="blue" mr={3}>
-              Lagre
+            <Button colorScheme={args.colorScheme} mr={3} variant="secondary">
+              Avbryt
             </Button>
-            <Button onClick={onClose}>Avbryt</Button>
+            <Button colorScheme={args.colorScheme} onClick={onClose} variant="primary">
+              Send inn skjema
+            </Button>
           </ModalFooter>
         </ModalContent>
       </KvibModal>
@@ -334,7 +337,6 @@ export const ModalFocus: Story = {
 
 const ModalCenteredExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-
   return (
     <>
       <Button onClick={onOpen}>Åpne modal</Button>
@@ -342,7 +344,7 @@ const ModalCenteredExample = ({ ...args }) => {
       <KvibModal {...args} onClose={onClose} isOpen={isOpen} isCentered>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Modal Sentrering</ModalHeader>
+          <ModalHeader>Sentrert modal</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             Modalen har 3.75rem vertical offset. Den kan endres ved å legge "top" til ModalContent. Hvis du skal
@@ -373,14 +375,14 @@ const ModalTransitionExample = ({ ...args }) => {
           <ModalHeader>Modal Transition</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            Modal kommer med scale transition, men du kan endre den med motionPreset-propen. Sett verdien til
-            "slideInBottom", "slideInRight", "scale" eller "none".
+            Modal kommer med en scale transition som du kan endre med motionPreset-propen. Sett verdien til
+            “slidelnBottom”, “slidelnRight”, “scale” eller “none”.
           </ModalBody>
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
-              Lukk
+            <Button mr={3} onClick={onClose} variant="secondary">
+              Avbryt
             </Button>
-            <Button variant="ghost">Annen handling</Button>
+            <Button variant="primary">Bekreft</Button>
           </ModalFooter>
         </ModalContent>
       </KvibModal>

--- a/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
+++ b/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Flex,
   FormControl,
   FormLabel,
   Input,
@@ -11,28 +12,32 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Select,
   Text,
   useDisclosure,
 } from "@kvib/react/src";
 import { Meta, StoryObj } from "@storybook/react";
-import { SetStateAction, useRef, useState } from "react";
+import { useRef, useState } from "react";
+import {
+  ModalBackdropString,
+  ModalCenteredString,
+  ModalFocusString,
+  ModalScrollingString,
+  ModalSizesString,
+  ModalString,
+  ModalTransitionString,
+} from "./srcStrings";
 
 const meta: Meta<typeof KvibModal> = {
   title: "Overlay/Modal",
   component: KvibModal,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: "shown" },
-    },
-  },
+
   argTypes: {
     isOpen: {
       name: "isOpen*",
       description: "If true, the modal will be open.",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
       },
       control: "boolean",
     },
@@ -48,7 +53,6 @@ const meta: Meta<typeof KvibModal> = {
       description: "Handle zoom/pinch gestures on iOS devices when scroll locking is enabled.",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
       },
       control: "boolean",
     },
@@ -57,7 +61,6 @@ const meta: Meta<typeof KvibModal> = {
         "If true, the modal will autofocus the first enabled and interactive element within the ModalContent",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: true },
       },
       control: "boolean",
     },
@@ -65,7 +68,6 @@ const meta: Meta<typeof KvibModal> = {
       description: "If true, scrolling will be disabled on the body when the modal opens.",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: true },
       },
       control: "boolean",
     },
@@ -73,7 +75,6 @@ const meta: Meta<typeof KvibModal> = {
       description: "If true, the modal will close when the Esc key is pressed",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: true },
       },
       control: "boolean",
     },
@@ -81,7 +82,6 @@ const meta: Meta<typeof KvibModal> = {
       description: "If true, the modal will close when the overlay is clicked",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: true },
       },
       control: "boolean",
     },
@@ -103,7 +103,6 @@ const meta: Meta<typeof KvibModal> = {
       description: "If true, the modal will be centered on screen.",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
       },
       control: "boolean",
     },
@@ -112,7 +111,6 @@ const meta: Meta<typeof KvibModal> = {
         "Enables aggressive focus capturing within iframes. - If true: keep focus in the lock, no matter where lock is active - If false: allows focus to move outside of iframe",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
       },
       control: "boolean",
     },
@@ -157,7 +155,6 @@ const meta: Meta<typeof KvibModal> = {
         "If true, a `padding-right` will be applied to the body element that's equal to the width of the scrollbar. This can help prevent some unpleasant flickering effect and content adjustment when the modal opens",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: true },
       },
       control: "boolean",
     },
@@ -165,7 +162,6 @@ const meta: Meta<typeof KvibModal> = {
       description: "If true, the modal will return focus to the element that triggered it when it closes.",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: true },
       },
       control: "boolean",
     },
@@ -192,7 +188,6 @@ const meta: Meta<typeof KvibModal> = {
         "If false, focus lock will be disabled completely. This is useful in situations where you still need to interact with other surrounding elements. 🚨Warning: We don't recommend doing this because it hurts the accessibility of the modal, based on WAI-ARIA specifications.",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: true },
       },
       control: "boolean",
     },
@@ -201,7 +196,6 @@ const meta: Meta<typeof KvibModal> = {
         "A11y: If true, the siblings of the modal will have `aria-hidden` set to true so that screen readers can only see the modal. This is commonly known as making the other elements **inert**",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: true },
       },
       control: "boolean",
     },
@@ -222,10 +216,10 @@ export const ModalExample = ({ ...args }) => {
   return (
     <>
       <Button onClick={onOpen} colorScheme={args.colorScheme}>
-        Åpne Modal
+        Åpne modal
       </Button>
 
-      <KvibModal {...args} isOpen={isOpen} onClose={onClose} colorScheme={args.colorScheme}>
+      <KvibModal {...args} isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Her er en modal</ModalHeader>
@@ -238,13 +232,11 @@ export const ModalExample = ({ ...args }) => {
             <Button onClick={onClose} variant="tertiary" colorScheme={args.colorScheme}>
               Tertiær
             </Button>
-            <Box mr={3}>
+            <Box>
               <Button mr={3} onClick={onClose} variant="secondary" colorScheme={args.colorScheme}>
                 Sekundær
               </Button>
-              <Button variant="primary" colorScheme={args.colorScheme}>
-                Primær
-              </Button>
+              <Button colorScheme={args.colorScheme}>Primær</Button>
             </Box>
           </ModalFooter>
         </ModalContent>
@@ -254,17 +246,25 @@ export const ModalExample = ({ ...args }) => {
 };
 
 export const Modal: Story = {
-  args: {},
   render: args => <ModalExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: ModalString,
+      },
+    },
+  },
 };
 
 const ModalScrollingExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>
-      <Button onClick={onOpen}>Åpne modal</Button>
+      <Button onClick={onOpen}>Åpne modal med scroll</Button>
 
-      <KvibModal {...args} blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
+      <KvibModal {...args} isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Modal med scroll</ModalHeader>
@@ -287,8 +287,19 @@ const ModalScrollingExample = ({ ...args }) => {
 };
 
 export const ModalScrolling: Story = {
-  args: {},
   render: args => <ModalScrollingExample {...args} />,
+  args: {
+    blockScrollOnMount: false,
+  },
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: ModalScrollingString,
+      },
+    },
+  },
 };
 
 const ModalFocusExample = ({ ...args }) => {
@@ -311,8 +322,8 @@ const ModalFocusExample = ({ ...args }) => {
           <ModalCloseButton />
           <ModalBody pb={6}>
             <FormControl>
-              <FormLabel>Navn</FormLabel>
-              <Input ref={initialRef} placeholder="Fornavn" />
+              <FormLabel>Skriv inn noe</FormLabel>
+              <Input ref={initialRef} placeholder="Placeholder" />
             </FormControl>
           </ModalBody>
 
@@ -331,8 +342,16 @@ const ModalFocusExample = ({ ...args }) => {
 };
 
 export const ModalFocus: Story = {
-  args: {},
   render: args => <ModalFocusExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: ModalFocusString,
+      },
+    },
+  },
 };
 
 const ModalCenteredExample = ({ ...args }) => {
@@ -346,10 +365,7 @@ const ModalCenteredExample = ({ ...args }) => {
         <ModalContent>
           <ModalHeader>Sentrert modal</ModalHeader>
           <ModalCloseButton />
-          <ModalBody>
-            Modalen har 3.75rem vertical offset. Den kan endres ved å legge "top" til ModalContent. Hvis du skal
-            sentrere vertikalt legger du isCentered i Modal.
-          </ModalBody>
+          <ModalBody>Denne modalen vises i midten av skjermen.</ModalBody>
           <ModalFooter>
             <Button onClick={onClose}>Lukk</Button>
           </ModalFooter>
@@ -360,8 +376,16 @@ const ModalCenteredExample = ({ ...args }) => {
 };
 
 export const ModalCentered: Story = {
-  args: {},
   render: args => <ModalCenteredExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: ModalCenteredString,
+      },
+    },
+  },
 };
 
 const ModalTransitionExample = ({ ...args }) => {
@@ -374,15 +398,12 @@ const ModalTransitionExample = ({ ...args }) => {
         <ModalContent>
           <ModalHeader>Modal Transition</ModalHeader>
           <ModalCloseButton />
-          <ModalBody>
-            Modal kommer med en scale transition som du kan endre med motionPreset-propen. Sett verdien til
-            “slidelnBottom”, “slidelnRight”, “scale” eller “none”.
-          </ModalBody>
+          <ModalBody>Denne modalen skyves inn med animasjon.</ModalBody>
           <ModalFooter>
             <Button mr={3} onClick={onClose} variant="secondary">
               Avbryt
             </Button>
-            <Button variant="primary">Bekreft</Button>
+            <Button>Bekreft</Button>
           </ModalFooter>
         </ModalContent>
       </KvibModal>
@@ -391,26 +412,37 @@ const ModalTransitionExample = ({ ...args }) => {
 };
 
 export const ModalTransition: Story = {
-  args: {},
   render: args => <ModalTransitionExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: ModalTransitionString,
+      },
+    },
+  },
 };
 
 const ModalSizeExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [size, setSize] = useState("md");
-
-  const handleSizeClick = (newSize: SetStateAction<string>) => {
-    setSize(newSize);
-    onOpen();
-  };
-
   const sizes = ["xs", "sm", "md", "lg", "xl", "full"];
 
   return (
     <>
-      {sizes.map(size => (
-        <Button onClick={() => handleSizeClick(size)} key={size} m={4}>{`Åpne ${size} Modal`}</Button>
-      ))}
+      <Flex gap="1rem" alignItems="center">
+        <Select onChange={e => setSize(e.target.value)} value={size} w="8rem">
+          {sizes.map(size => (
+            <option key={size} value={size}>
+              {size}
+            </option>
+          ))}
+        </Select>
+        <Button onClick={onOpen} m={4}>
+          Åpne modal
+        </Button>
+      </Flex>
 
       <KvibModal {...args} onClose={onClose} size={size} isOpen={isOpen}>
         <ModalOverlay />
@@ -418,8 +450,7 @@ const ModalSizeExample = ({ ...args }) => {
           <ModalHeader>Modal Størrelser</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            Bruk size-proppen hvis du vil endre størrelse. Verdiene du kan velge mellom er xs, sm, md, lg, xl, eller
-            full.
+            Du har åpnet modalen i størrelse <b>{size}</b>.
           </ModalBody>
           <ModalFooter>
             <Button onClick={onClose}>Lukk</Button>
@@ -431,8 +462,16 @@ const ModalSizeExample = ({ ...args }) => {
 };
 
 export const ModalSizes: Story = {
-  args: {},
   render: args => <ModalSizeExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: ModalSizesString,
+      },
+    },
+  },
 };
 
 const ModalBackdropExample = ({ ...args }) => {
@@ -451,7 +490,7 @@ const ModalBackdropExample = ({ ...args }) => {
           onOpen();
         }}
       >
-        Bruk overlay 1
+        Åpne modal med blurry bakgrunn
       </Button>
       <Button
         ml="4"
@@ -460,7 +499,7 @@ const ModalBackdropExample = ({ ...args }) => {
           onOpen();
         }}
       >
-        Bruk overlay 2
+        Åpne modal med inverterte farger
       </Button>
       <KvibModal {...args} isCentered isOpen={isOpen} onClose={onClose}>
         {overlay}
@@ -480,6 +519,14 @@ const ModalBackdropExample = ({ ...args }) => {
 };
 
 export const ModalBackdrop: Story = {
-  args: {},
   render: args => <ModalBackdropExample {...args} />,
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+        language: "tsx",
+        code: ModalBackdropString,
+      },
+    },
+  },
 };

--- a/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
+++ b/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
@@ -434,7 +434,7 @@ const ModalSizeExample = ({ ...args }) => {
       <FormControl>
         <FormLabel htmlFor="select">Velg størrelse for modal</FormLabel>
         <Flex gap="0.5rem">
-          <Select aria-label="Velg størrelse for modal" onChange={e => setSize(e.target.value)} value={size} w="8rem">
+          <Select id="select" onChange={e => setSize(e.target.value)} value={size} w="8rem">
             {sizes.map(size => (
               <option key={size} value={size}>
                 {size}

--- a/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
+++ b/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
@@ -431,23 +431,24 @@ const ModalSizeExample = ({ ...args }) => {
 
   return (
     <>
-      <Flex gap="1rem" alignItems="center">
-        <Select onChange={e => setSize(e.target.value)} value={size} w="8rem">
-          {sizes.map(size => (
-            <option key={size} value={size}>
-              {size}
-            </option>
-          ))}
-        </Select>
-        <Button onClick={onOpen} m={4}>
-          Åpne modal
-        </Button>
-      </Flex>
+      <FormControl>
+        <FormLabel htmlFor="select">Velg størrelse for modal</FormLabel>
+        <Flex gap="0.5rem">
+          <Select aria-label="Velg størrelse for modal" onChange={e => setSize(e.target.value)} value={size} w="8rem">
+            {sizes.map(size => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </Select>
+          <Button onClick={onOpen}>Åpne modal</Button>
+        </Flex>
+      </FormControl>
 
       <KvibModal {...args} onClose={onClose} size={size} isOpen={isOpen}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Modal Størrelser</ModalHeader>
+          <ModalHeader>Modal i forskjellige størrelser</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             Du har åpnet modalen i størrelse <b>{size}</b>.

--- a/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
+++ b/apps/storybook/stories/components/overlay/modal/Modal.stories.tsx
@@ -211,7 +211,7 @@ const meta: Meta<typeof KvibModal> = {
 export default meta;
 type Story = StoryObj<typeof KvibModal>;
 
-export const ModalExample = ({ ...args }) => {
+const ModalExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>

--- a/apps/storybook/stories/components/overlay/modal/srcStrings.ts
+++ b/apps/storybook/stories/components/overlay/modal/srcStrings.ts
@@ -150,23 +150,24 @@ const sizes = ["xs", "sm", "md", "lg", "xl", "full"];
 
 return (
   <>
-    <Flex gap="1rem" alignItems="center">
-      <Select onChange={e => setSize(e.target.value)} value={size} w="8rem">
-        {sizes.map(size => (
-          <option key={size} value={size}>
-            {size}
-          </option>
-        ))}
-      </Select>
-      <Button onClick={onOpen} m={4}>
-        Åpne modal
-      </Button>
-    </Flex>
+    <FormControl>
+      <FormLabel htmlFor="select">Velg størrelse for modal</FormLabel>
+      <Flex gap="0.5rem">
+        <Select id="select" onChange={e => setSize(e.target.value)} value={size} w="8rem">
+          {sizes.map(size => (
+            <option key={size} value={size}>
+              {size}
+            </option>
+          ))}
+        </Select>
+        <Button onClick={onOpen}>Åpne modal</Button>
+      </Flex>
+    </FormControl>
 
-    <Modal onClose={onClose} size={size} isOpen={isOpen}>
+    <KvibModal {...args} onClose={onClose} size={size} isOpen={isOpen}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>Modal Størrelser</ModalHeader>
+        <ModalHeader>Modal i forskjellige størrelser</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
           Du har åpnet modalen i størrelse <b>{size}</b>.
@@ -175,7 +176,7 @@ return (
           <Button onClick={onClose}>Lukk</Button>
         </ModalFooter>
       </ModalContent>
-    </Modal>
+    </KvibModal>
   </>
 );
 `;

--- a/apps/storybook/stories/components/overlay/modal/srcStrings.ts
+++ b/apps/storybook/stories/components/overlay/modal/srcStrings.ts
@@ -1,229 +1,225 @@
-export const ModalString = `const ModalExample = ({ ...args }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  return (
-    <>
-      <Button onClick={onOpen}>
-        Åpne Modal
-      </Button>
+export const ModalString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+return (
+  <>
+    <Button onClick={onOpen} colorScheme={args.colorScheme}>
+      Åpne modal
+    </Button>
 
-      <KvibModal {...args} isOpen={isOpen} onClose={onClose}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Her er en modal</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            Modaler må kun vises etter en brukerinteraksjon, og skal ikke avbryte brukeren på noe vis.
-          </ModalBody>
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Her er en modal</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          Modaler må kun vises etter en brukerinteraksjon, og skal ikke avbryte brukeren på noe vis.
+        </ModalBody>
 
-          <ModalFooter justifyContent="space-between">
-            <Button onClick={onClose} variant="tertiary">
-              Tertiær
-            </Button>
-            <Box mr={3}>
-              <Button mr={3} onClick={onClose} variant="secondary">
-                Sekundær
-              </Button>
-              <Button variant="primary">Primær</Button>
-            </Box>
-          </ModalFooter>
-        </ModalContent>
-      </KvibModal>
-    </>
-  );
-};`;
-
-export const ModalScrollingString = `const ModalScrollingExample = ({ ...args }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  return (
-    <>
-      <Button onClick={onOpen}>Åpne modal</Button>
-
-      <KvibModal {...args} blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Modal med scroll</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            <Text fontWeight="bold" mb="1rem">
-              Her er en modal hvor du kan scrolle innholdet bak.
-            </Text>
-          </ModalBody>
-          <ModalFooter>
+        <ModalFooter justifyContent="space-between">
+          <Button onClick={onClose} variant="tertiary">
+            Tertiær
+          </Button>
+          <Box>
             <Button mr={3} onClick={onClose} variant="secondary">
-              Avbryt
+              Sekundær
             </Button>
-            <Button variant="primary">Bekreft</Button>
-          </ModalFooter>
-        </ModalContent>
-      </KvibModal>
-    </>
-  );
-};`;
+            <Button>Primær</Button>
+          </Box>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  </>
+);
+`;
 
-export const ModalFocusString = `const ModalFocusExample = ({ ...args }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+export const ModalScrollingString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+return (
+  <>
+    <Button onClick={onOpen}>Åpne modal med scroll</Button>
 
-  const initialRef = useRef(null);
-  const finalRef = useRef(null);
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Modal med scroll</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text fontWeight="bold" mb="1rem">
+            Her er en modal hvor du kan scrolle innholdet bak.
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose} variant="secondary">
+            Avbryt
+          </Button>
+          <Button>Bekreft</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  </>
+);
+`;
 
-  return (
-    <>
-      <Button onClick={onOpen}>Åpne modal</Button>
-      <Button ml={4} ref={finalRef}>
-        Jeg får fokus på close
+export const ModalFocusString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+
+const initialRef = useRef(null);
+const finalRef = useRef(null);
+
+return (
+  <>
+    <Button onClick={onOpen}>Åpne modal</Button>
+    <Button ml={4} ref={finalRef}>
+      Jeg får fokus på close
+    </Button>
+
+    <Modal initialFocusRef={initialRef} finalFocusRef={finalRef} isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Modal med skjema</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={6}>
+          <FormControl>
+            <FormLabel>Skriv inn noe</FormLabel>
+            <Input ref={initialRef} placeholder="Placeholder" />
+          </FormControl>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button mr={3} variant="secondary">
+            Avbryt
+          </Button>
+          <Button onClick={onClose}>
+            Send inn skjema
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  </>
+);
+`;
+
+export const ModalCenteredString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+return (
+  <>
+    <Button onClick={onOpen}>Åpne modal</Button>
+
+    <Modal onClose={onClose} isOpen={isOpen} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Sentrert modal</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>Denne modalen vises i midten av skjermen.</ModalBody>
+        <ModalFooter>
+          <Button onClick={onClose}>Lukk</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  </>
+);
+`;
+
+export const ModalTransitionString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+return (
+  <>
+    <Button onClick={onOpen}>Åpne modal</Button>
+    <Modal isCentered onClose={onClose} isOpen={isOpen} motionPreset="slideInBottom">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Modal Transition</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>Denne modalen skyves inn med animasjon.</ModalBody>
+        <ModalFooter>
+          <Button mr={3} onClick={onClose} variant="secondary">
+            Avbryt
+          </Button>
+          <Button>Bekreft</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  </>
+);
+`;
+
+export const ModalSizesString = `
+const { isOpen, onOpen, onClose } = useDisclosure();
+const [size, setSize] = useState("md");
+const sizes = ["xs", "sm", "md", "lg", "xl", "full"];
+
+return (
+  <>
+    <Flex gap="1rem" alignItems="center">
+      <Select onChange={e => setSize(e.target.value)} value={size} w="8rem">
+        {sizes.map(size => (
+          <option key={size} value={size}>
+            {size}
+          </option>
+        ))}
+      </Select>
+      <Button onClick={onOpen} m={4}>
+        Åpne modal
       </Button>
+    </Flex>
 
-      <KvibModal {...args} initialFocusRef={initialRef} finalFocusRef={finalRef} isOpen={isOpen} onClose={onClose}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Modal med skjema</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody pb={6}>
-            <FormControl>
-              <FormLabel>Navn</FormLabel>
-              <Input ref={initialRef} placeholder="Fornavn" />
-            </FormControl>
-          </ModalBody>
+    <Modal onClose={onClose} size={size} isOpen={isOpen}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Modal Størrelser</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          Du har åpnet modalen i størrelse <b>{size}</b>.
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={onClose}>Lukk</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  </>
+);
+`;
 
-          <ModalFooter>
-            <Button colorScheme={args.colorScheme} mr={3} variant="secondary">
-              Avbryt
-            </Button>
-            <Button colorScheme={args.colorScheme} onClick={onClose} variant="primary">
-              Send inn skjema
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </KvibModal>
-    </>
-  );
-};`;
+export const ModalBackdropString = `
+const OverlayOne = () => <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px) hue-rotate(90deg)" />;
 
-export const ModalCenteredString = `const ModalCenteredExample = ({ ...args }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  return (
-    <>
-      <Button onClick={onOpen}>Åpne modal</Button>
+const OverlayTwo = () => <ModalOverlay bg="none" backdropFilter="auto" backdropInvert="80%" backdropBlur="2px" />;
 
-      <KvibModal {...args} onClose={onClose} isOpen={isOpen} isCentered>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Sentrert modal</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            Modalen har 3.75rem vertical offset. Den kan endres ved å legge "top" til ModalContent. Hvis du skal
-            sentrere vertikalt legger du isCentered i Modal.
-          </ModalBody>
-          <ModalFooter>
-            <Button onClick={onClose}>Lukk</Button>
-          </ModalFooter>
-        </ModalContent>
-      </KvibModal>
-    </>
-  );
-};`;
+const { isOpen, onOpen, onClose } = useDisclosure();
+const [overlay, setOverlay] = useState(<OverlayOne />);
 
-export const ModalTransitionString = `const ModalTransitionExample = ({ ...args }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  return (
-    <>
-      <Button onClick={onOpen}>Åpne modal</Button>
-      <KvibModal {...args} isCentered onClose={onClose} isOpen={isOpen} motionPreset="slideInBottom">
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Modal Transition</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            Modal kommer med en scale transition som du kan endre med motionPreset-propen. Sett verdien til
-            “slidelnBottom”, “slidelnRight”, “scale” eller “none”.
-          </ModalBody>
-          <ModalFooter>
-            <Button mr={3} onClick={onClose} variant="secondary">
-              Avbryt
-            </Button>
-            <Button variant="primary">Bekreft</Button>
-          </ModalFooter>
-        </ModalContent>
-      </KvibModal>
-    </>
-  );
-};`;
-
-export const ModalSizesString = `const ModalSizeExample = ({ ...args }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const [size, setSize] = useState("md");
-
-  const handleSizeClick = (newSize: SetStateAction<string>) => {
-    setSize(newSize);
-    onOpen();
-  };
-
-  const sizes = ["xs", "sm", "md", "lg", "xl", "full"];
-
-  return (
-    <>
-      {sizes.map((size) => (
-        <Button onClick={() => handleSizeClick(size)} key={size} m={4}>{\`Åpne \${size} Modal\`}</Button>
-      ))}
-
-      <Modal onClose={onClose} size={size} isOpen={isOpen}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Modal Størrelser</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            Bruk size-proppen hvis du vil endre størrelse. Verdiene du kan velge mellom er xs, sm, md, lg, xl, eller
-            full.
-          </ModalBody>
-          <ModalFooter>
-            <Button onClick={onClose}>Lukk</Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-    </>
-  );
-};`;
-
-export const ModalBackdropString = `const ModalBackdropExample = ({ ...args }) => {
-  const OverlayOne = () => <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(10px) hue-rotate(90deg)" />;
-
-  const OverlayTwo = () => <ModalOverlay bg="none" backdropFilter="auto" backdropInvert="80%" backdropBlur="2px" />;
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const [overlay, setOverlay] = useState(<OverlayOne />);
-
-  return (
-    <>
-      <Button
-        onClick={() => {
-          setOverlay(<OverlayOne />);
-          onOpen();
-        }}
-      >
-        Bruk overlay 1
-      </Button>
-      <Button
-        ml="4"
-        onClick={() => {
-          setOverlay(<OverlayTwo />);
-          onOpen();
-        }}
-      >
-        Bruk overlay 2
-      </Button>
-      <Modal isCentered isOpen={isOpen} onClose={onClose}>
-        {overlay}
-        <ModalContent>
-          <ModalHeader>Bakteppe</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody>
-            <Text>Egendefinerte baktepper!</Text>
-          </ModalBody>
-          <ModalFooter>
-            <Button onClick={onClose}>Lukk</Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-    </>
-  );
-};`;
+return (
+  <>
+    <Button
+      onClick={() => {
+        setOverlay(<OverlayOne />);
+        onOpen();
+      }}
+    >
+      Åpne modal med blurry bakgrunn
+    </Button>
+    <Button
+      ml="4"
+      onClick={() => {
+        setOverlay(<OverlayTwo />);
+        onOpen();
+      }}
+    >
+      Åpne modal med inverterte farger
+    </Button>
+    <Modal isCentered isOpen={isOpen} onClose={onClose}>
+      {overlay}
+      <ModalContent>
+        <ModalHeader>Bakteppe</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text>Egendefinerte baktepper!</Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={onClose}>Lukk</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  </>
+);
+`;

--- a/apps/storybook/stories/components/overlay/modal/srcStrings.ts
+++ b/apps/storybook/stories/components/overlay/modal/srcStrings.ts
@@ -2,55 +2,60 @@ export const ModalString = `const ModalExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>
-      <Button onClick={onOpen}>Åpne Modal</Button>
+      <Button onClick={onOpen}>
+        Åpne Modal
+      </Button>
 
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <KvibModal {...args} isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Historiske kart</ModalHeader>
+          <ModalHeader>Her er en modal</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            Vil du ha eit gammalt kart på hytteveggen? Historiske kart kan lastast ned og skrivast ut gratis. Ta ein
-            kikk i vårt arkiv!
+            Modaler må kun vises etter en brukerinteraksjon, og skal ikke avbryte brukeren på noe vis.
           </ModalBody>
 
-          <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
-              Lukk
+          <ModalFooter justifyContent="space-between">
+            <Button onClick={onClose} variant="tertiary">
+              Tertiær
             </Button>
-            <Button>Ta en kikk</Button>
+            <Box mr={3}>
+              <Button mr={3} onClick={onClose} variant="secondary">
+                Sekundær
+              </Button>
+              <Button variant="primary">Primær</Button>
+            </Box>
           </ModalFooter>
         </ModalContent>
-      </Modal>
+      </KvibModal>
     </>
   );
 };`;
 
 export const ModalScrollingString = `const ModalScrollingExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-
   return (
     <>
       <Button onClick={onOpen}>Åpne modal</Button>
 
-      <Modal blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
+      <KvibModal {...args} blockScrollOnMount={false} isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Modal tittel</ModalHeader>
+          <ModalHeader>Modal med scroll</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             <Text fontWeight="bold" mb="1rem">
-              Du kan scrolle i innholdet bak modalen
+              Her er en modal hvor du kan scrolle innholdet bak.
             </Text>
           </ModalBody>
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
-              Lukk
+            <Button mr={3} onClick={onClose} variant="secondary">
+              Avbryt
             </Button>
-            <Button variant="ghost">Annen handling</Button>
+            <Button variant="primary">Bekreft</Button>
           </ModalFooter>
         </ModalContent>
-      </Modal>
+      </KvibModal>
     </>
   );
 };`;
@@ -68,46 +73,42 @@ export const ModalFocusString = `const ModalFocusExample = ({ ...args }) => {
         Jeg får fokus på close
       </Button>
 
-      <Modal initialFocusRef={initialRef} finalFocusRef={finalRef} isOpen={isOpen} onClose={onClose}>
+      <KvibModal {...args} initialFocusRef={initialRef} finalFocusRef={finalRef} isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Lag konto</ModalHeader>
+          <ModalHeader>Modal med skjema</ModalHeader>
           <ModalCloseButton />
           <ModalBody pb={6}>
             <FormControl>
-              <FormLabel>Fornavn</FormLabel>
+              <FormLabel>Navn</FormLabel>
               <Input ref={initialRef} placeholder="Fornavn" />
-            </FormControl>
-
-            <FormControl>
-              <FormLabel>Etternavn</FormLabel>
-              <Input placeholder="Etternavn" />
             </FormControl>
           </ModalBody>
 
           <ModalFooter>
-            <Button colorScheme="blue" mr={3}>
-              Lagre
+            <Button colorScheme={args.colorScheme} mr={3} variant="secondary">
+              Avbryt
             </Button>
-            <Button onClick={onClose}>Avbryt</Button>
+            <Button colorScheme={args.colorScheme} onClick={onClose} variant="primary">
+              Send inn skjema
+            </Button>
           </ModalFooter>
         </ModalContent>
-      </Modal>
+      </KvibModal>
     </>
   );
 };`;
 
 export const ModalCenteredString = `const ModalCenteredExample = ({ ...args }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-
   return (
     <>
       <Button onClick={onOpen}>Åpne modal</Button>
 
-      <Modal onClose={onClose} isOpen={isOpen} isCentered>
+      <KvibModal {...args} onClose={onClose} isOpen={isOpen} isCentered>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Modal Sentrering</ModalHeader>
+          <ModalHeader>Sentrert modal</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             Modalen har 3.75rem vertical offset. Den kan endres ved å legge "top" til ModalContent. Hvis du skal
@@ -117,7 +118,7 @@ export const ModalCenteredString = `const ModalCenteredExample = ({ ...args }) =
             <Button onClick={onClose}>Lukk</Button>
           </ModalFooter>
         </ModalContent>
-      </Modal>
+      </KvibModal>
     </>
   );
 };`;
@@ -127,23 +128,23 @@ export const ModalTransitionString = `const ModalTransitionExample = ({ ...args 
   return (
     <>
       <Button onClick={onOpen}>Åpne modal</Button>
-      <Modal isCentered onClose={onClose} isOpen={isOpen} motionPreset="slideInBottom">
+      <KvibModal {...args} isCentered onClose={onClose} isOpen={isOpen} motionPreset="slideInBottom">
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Modal Transition</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            Modal kommer med scale transition, men du kan endre den med motionPreset-propen. Sett verdien til
-            "slideInBottom", "slideInRight", "scale" eller "none".
+            Modal kommer med en scale transition som du kan endre med motionPreset-propen. Sett verdien til
+            “slidelnBottom”, “slidelnRight”, “scale” eller “none”.
           </ModalBody>
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
-              Lukk
+            <Button mr={3} onClick={onClose} variant="secondary">
+              Avbryt
             </Button>
-            <Button variant="ghost">Annen handling</Button>
+            <Button variant="primary">Bekreft</Button>
           </ModalFooter>
         </ModalContent>
-      </Modal>
+      </KvibModal>
     </>
   );
 };`;

--- a/apps/storybook/stories/documentation/komponentoversikt/Komponenter.tsx
+++ b/apps/storybook/stories/documentation/komponentoversikt/Komponenter.tsx
@@ -99,9 +99,7 @@ import {
 } from "@kvib/react/src";
 import { ReactElement } from "react";
 import { PortalNestedExample } from "../../components/annet/portal/Portal.stories";
-import { AlertDialogExample } from "../../components/overlay/alert-dialog/AlertDialog.stories";
 import { DrawerExample } from "../../components/overlay/drawer/Drawer.stories";
-import { ModalExample } from "../../components/overlay/modal/Modal.stories";
 
 interface Komponentdetaljer {
   navn: string;
@@ -756,12 +754,13 @@ export const Komponenter: (colorScheme: "green" | "blue") => Record<string, Kate
         komponent: <Tooltip label="Dette er en tooltip">Hover over meg</Tooltip>,
         link: "tooltip",
       },
-      Modal: {
+      // TODO: Legg til modal direkte fra Story
+      /* Modal: {
         navn: "Modal",
         beskrivelse: "",
         komponent: <ModalExample colorScheme={colorScheme} />,
         link: "modal",
-      },
+      }, */
       Popover: {
         navn: "Popover",
         beskrivelse: "",
@@ -780,12 +779,13 @@ export const Komponenter: (colorScheme: "green" | "blue") => Record<string, Kate
         ),
         link: "popover",
       },
-      AlertDialog: {
+      // TODO: Legg til AlertDialog direkte fra Story
+      /* AlertDialog: {
         navn: "Alert Dialog",
         beskrivelse: "",
-        komponent: <AlertDialogExample />,
+        komponent:
         link: "alert-dialog",
-      },
+      }, */
       Drawer: {
         navn: "Drawer",
         beskrivelse: "",

--- a/apps/storybook/stories/templates/DocsContainer.tsx
+++ b/apps/storybook/stories/templates/DocsContainer.tsx
@@ -1,7 +1,8 @@
 import { Box } from "@kvib/react/src";
+import { ReactNode } from "react";
 
 type DocsStoriesContainerProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export const DocsContainer = ({ children }: DocsStoriesContainerProps) => {


### PR DESCRIPTION
Endrer Modal og AlertDialog sine stories til å bruke Canvas med kodeeksempler som er skjult som standard. Innholdet i modalene som popper opp i eksemplene har også blitt mer overordnede, samt at de benytter seg av best practices når det kommer til knappeposisjoner og variant-hierarki.

Før/etter på standard modal:

![image](https://github.com/user-attachments/assets/297dc6ea-1075-4b25-83a6-2484938e78a1)

![image](https://github.com/user-attachments/assets/ee3f7912-e8a2-46f6-99f2-201b19742ead)
