### PR TITLE
Støtte for å fjerne personvernslenke i Footer

### DIFF
--- a/.changeset/two-weeks-try.md
+++ b/.changeset/two-weeks-try.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Legger til valg for å fjerne personvernslenke i Footer

--- a/apps/storybook/stories/components/sideelementer/footer/footer/Footer.mdx
+++ b/apps/storybook/stories/components/sideelementer/footer/footer/Footer.mdx
@@ -9,36 +9,26 @@ import * as FooterStories from "./Footer.stories";
 
 # Footer
 
-```jsx
-import { Footer } from "@kvib/react";
-```
+En footer er en seksjon som vises nederst på en nettside. Rett ut av boksen inneholder den en logo sammen med Kartverkets kontaktopplysninger og lenker til relevante sider.
+
+<Canvas of={FooterStories.Preview} sourceState="hidden" />
 
 <Feedback components="Footer" />
 
-<DocsStory
-  isVertical
-  title="Footer med innhold"
-  description={""}
-  story={
-    <>
-      <Canvas of={FooterStories.Preview} sourceState="hidden" />
-      Props
-      <Controls of={FooterStories.Preview} />
-    </>
-  }
-/>
+## Slik bruker du Footer
+For å bruke Footer, importerer du den fra `@kvib/react`-pakken på følgende måte:
+```tsx
+import { Footer } from "@kvib/react";
+```
+<br/><br/>
 
-<DocsStory
-  isVertical
-  title="Footer uten innhold"
-  description={""}
-  story={
-    <>
-      <Canvas of={FooterStories.FooterNone} sourceState="hidden" />
-      Props
-      <Controls of={FooterStories.FooterNone} />
-    </>
-  }
-/>
+### Fjern elementer fra Footer
+Footeren er satt opp slik at den inneholder alt rett ut av boksen. Dersom man ønsker å fjerne elementer finnes det en rekke `exclude*`-props som kan brukes til dette.
+<Canvas of={FooterStories.FooterNone} sourceState="hidden" />
+
+
+## Props
+<Canvas of={FooterStories.Preview} sourceState="hidden" />
+<Controls of={FooterStories.Preview} />
 
 </DocsContainer>

--- a/apps/storybook/stories/components/sideelementer/footer/footer/Footer.stories.tsx
+++ b/apps/storybook/stories/components/sideelementer/footer/footer/Footer.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof KvibFooter> = {
       description: "Exclude contact information",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -27,7 +27,7 @@ const meta: Meta<typeof KvibFooter> = {
       description: "Exclude help",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -35,7 +35,7 @@ const meta: Meta<typeof KvibFooter> = {
       description: "Exclude news",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -43,7 +43,15 @@ const meta: Meta<typeof KvibFooter> = {
       description: "Exclude opening hours",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
+        defaultValue: { summary: "false" },
+      },
+      control: "boolean",
+    },
+    excludePrivacyLink: {
+      description: "Exclude privacy link",
+      table: {
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -51,7 +59,7 @@ const meta: Meta<typeof KvibFooter> = {
       description: "Exclude social media",
       table: {
         type: { summary: "boolean" },
-        defaultValue: { summary: false },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -71,6 +79,7 @@ export const Preview: Story = {
     excludeHelp: false,
     excludeNews: false,
     excludeOpeningHours: false,
+    excludePrivacyLink: false,
     excludeSocialMedia: false,
   },
   render: args => <KvibFooter {...args} />,
@@ -83,6 +92,7 @@ export const FooterNone: Story = {
     excludeHelp: true,
     excludeNews: true,
     excludeOpeningHours: true,
+    excludePrivacyLink: true,
     excludeSocialMedia: true,
   },
   render: args => <KvibFooter {...args} />,

--- a/packages/react/src/footer/Footer.tsx
+++ b/packages/react/src/footer/Footer.tsx
@@ -2,6 +2,7 @@ import { Box, Divider, Flex, FlexProps, Heading, Link, Logo, Text } from "@kvib/
 
 export type FooterProps = {
   accessibilityUrl?: string;
+  excludePrivacyLink?: boolean;
   excludeSocialMedia?: boolean;
   excludeOpeningHours?: boolean;
   excludeContactInfo?: boolean;
@@ -29,6 +30,7 @@ export const Footer = ({
   excludeHelp,
   excludeNews,
   excludeSocialMedia,
+  excludePrivacyLink,
   contactInfoEmailAddress = "post@kartverket.no",
 }: FooterProps) => {
   const onlyOneIncluded =
@@ -195,13 +197,15 @@ export const Footer = ({
             </FooterToggleableFlex>
           )}
           <Flex align="center" gap={3} flexWrap="wrap">
-            <Link
-              href="https://kartverket.no/om-kartverket/personvern"
-              aria-label="Besøk Kartverket sin personvernserklæring"
-              fontWeight="bold"
-            >
-              Personvern
-            </Link>
+            {!excludePrivacyLink && (
+              <Link
+                href="https://kartverket.no/om-kartverket/personvern"
+                aria-label="Besøk Kartverket sin personvernserklæring"
+                fontWeight="bold"
+              >
+                Personvern
+              </Link>
+            )}
             {accessibilityUrl && (
               <Link href={accessibilityUrl} aria-label="Besøk denne sidens tilgjengelighetserklæring" fontWeight="bold">
                 {" "}


### PR DESCRIPTION
Etter innspill fra teamene som bruker `Footer` er det behov for å fjerne alle elementer fra denne komponenten, og frem til nå har man kunne fjerne alt utenom lenken til Kartverkets personvernsider. Denne PR-en legger til prop-en `excludePrivacyLink` som brukes på samme måte som de eksisterende `exclude`-lenkene for å kunne ta bort nettopp denne personvernslenken.

Fra nå vil det være mulig å strippe Footeren ned til å kun inneholde logo:
![image](https://github.com/user-attachments/assets/66db17e9-9a03-424b-aa73-60f0515d3ac9)
