### PR TITLE
Fikser bug i Datepicker

### DIFF
--- a/.changeset/many-walls-sit.md
+++ b/.changeset/many-walls-sit.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Fiks for onChange i Datepicker som ikke ble trigget

--- a/apps/storybook/.storybook/docs-root.css
+++ b/apps/storybook/.storybook/docs-root.css
@@ -88,11 +88,6 @@ input[type="range"]::-webkit-slider-thumb:active {
   overflow: hidden;
 }
 
-#downshift-0-menu {
-  margin-left: -15px !important; /* storybook setter -20px her, det er alt for mye */
-  margin-right: -20px !important; /* storybook setter -20px her, det er alt for mye */
-}
-
 .toc-wrapper {
   padding: 0 12px;
 }

--- a/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.stories.tsx
+++ b/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.stories.tsx
@@ -160,7 +160,7 @@ type Story = StoryObj<typeof KvibDatepicker>;
 export const Preview: Story = {
   args: {
     placeholder: "Velg dato",
-    onChange: v => console.log("Datepicker changed", v),
+    onChange: v => console.log("Du endret dato i Datepicker til " + v.target.value),
     "aria-label": "Datepicker example",
   },
   render: args => <KvibDatepicker {...args} />,

--- a/packages/react/src/datepicker/Datepicker.tsx
+++ b/packages/react/src/datepicker/Datepicker.tsx
@@ -187,7 +187,7 @@ const CustomDatepicker = forwardRef<DatepickerProps, "input">(
     const effectiveOnChange = (event: ChangeEvent<HTMLInputElement>) => {
       // Then, call the onChange from props if it the input is valid
       const dateStr = event.target.value;
-      const parsedDate = parse(dateStr, "yyyy-MM-dd", new Date());
+      const parsedDate = parse(dateStr, "dd.MM.yyyy", new Date());
       if (isValid(parsedDate)) {
         onChange?.(event);
       }


### PR DESCRIPTION
En bug i parsingen av datoer i `Daypicker` gjorde at ugyldige datoer hindret `onChange` å bli kjørt, og en oppdatering i `date-fns` gjorde at denne sjekken måtte gjøres litt annerledes enn før og dermed klagde på ugyldige datoer. Retter opp i dette nå 🤞🏼 