### PR TITLE
Refaktorerer Datepicker

### DIFF
--- a/.changeset/cool-socks-compete.md
+++ b/.changeset/cool-socks-compete.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Bedre datohåndtering med tekstfeltet i Datepicker, fiks for onChange som ikke ble trigget, mulighet for å sende inn useNative-prop for større skjermer enn kun på mobil

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import "./docs-root.css";
 import theme from "./theme";
 
 const parameters = {
+  actions: { argTypesRegex: "^on.*" },
   backgrounds: {
     default: "light",
     values: [{ name: "light", value: "#ffffff" }],

--- a/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.stories.tsx
+++ b/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.stories.tsx
@@ -1,11 +1,16 @@
 import { FormControl, FormLabel, Stack } from "@kvib/react/src";
 import { Datepicker as KvibDatepicker } from "@kvib/react/src/datepicker";
+import { withActions } from "@storybook/addon-actions/decorator";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof KvibDatepicker> = {
   title: "Komponenter/Datepicker",
   component: KvibDatepicker,
+  decorators: [withActions],
   parameters: {
+    actions: {
+      argTypesRegex: "^on.*",
+    },
     docs: {
       story: { inline: true },
       canvas: { sourceState: "hidden" },
@@ -14,12 +19,36 @@ const meta: Meta<typeof KvibDatepicker> = {
       // This option disables all a11y checks on this story
     },
   },
+  args: {
+    placeholder: "Velg dato",
+    size: "md",
+    variant: "outline",
+    colorScheme: "green",
+    isRequired: false,
+    isInvalid: false,
+    isDisabled: false,
+    useNative: false,
+    disableNavigation: false,
+    showWeekNumber: false,
+    showOutsideDays: false,
+    showDropdownMonthYear: false,
+    defaultSelected: undefined,
+    defaultMonth: undefined,
+    fromDate: undefined,
+    toDate: undefined,
+  },
   argTypes: {
+    placeholder: {
+      description: "Placeholder text",
+      table: {
+        type: { summary: "string" },
+      },
+      control: "text",
+    },
     size: {
       description: "Size of input",
       table: {
         type: { summary: "lg | md | sm | xs" },
-        defaultValue: { summary: "md" },
       },
       options: ["lg", "md", "sm", "xs"],
       control: { type: "radio" },
@@ -28,7 +57,6 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "Variant",
       table: {
         type: { summary: "outline | filled | flushed | unstyled" },
-        defaultValue: { summary: "outline" },
       },
       options: ["outline", "filled", "flushed", "unstyled"],
       control: { type: "radio" },
@@ -36,9 +64,9 @@ const meta: Meta<typeof KvibDatepicker> = {
     isRequired: {
       description: "Toggles if input should be required",
       table: {
-        type: { summary: "boolean" },
-        defaultValue: { summary: "false" },
+        type: { summary: "Boolean" },
       },
+      defaultValue: { summary: "false" },
       control: "boolean",
     },
     isInvalid: {
@@ -64,7 +92,6 @@ const meta: Meta<typeof KvibDatepicker> = {
       },
       control: "date",
     },
-
     defaultMonth: {
       description: "The month to display in the calendar by default.",
       table: {
@@ -72,7 +99,6 @@ const meta: Meta<typeof KvibDatepicker> = {
       },
       control: "date",
     },
-
     fromDate: {
       description: "The earliest date available for selection.",
       table: {
@@ -80,7 +106,6 @@ const meta: Meta<typeof KvibDatepicker> = {
       },
       control: "date",
     },
-
     toDate: {
       description: "The latest date available for selection.",
       table: {
@@ -88,7 +113,6 @@ const meta: Meta<typeof KvibDatepicker> = {
       },
       control: "date",
     },
-
     showDropdownMonthYear: {
       description:
         "Whether or not to show dropdowns for month and year selection. `fromDate` and `toDate` must be set.",
@@ -97,7 +121,6 @@ const meta: Meta<typeof KvibDatepicker> = {
       },
       control: "boolean",
     },
-
     disableNavigation: {
       description: "If set to true, navigation buttons (next/previous month) are hidden.",
       table: {
@@ -105,7 +128,6 @@ const meta: Meta<typeof KvibDatepicker> = {
       },
       control: "boolean",
     },
-
     showOutsideDays: {
       description: "Whether or not to show the days that fall outside the current month.",
       table: {
@@ -113,7 +135,6 @@ const meta: Meta<typeof KvibDatepicker> = {
       },
       control: "boolean",
     },
-
     showWeekNumber: {
       description: "Whether or not to display the week numbers.",
       table: {
@@ -121,26 +142,18 @@ const meta: Meta<typeof KvibDatepicker> = {
       },
       control: "boolean",
     },
-
     disabledDays: {
       description: "A list of dates that should be disabled for selection.",
-      table: {
-        type: { summary: "Date[]" },
+      control: {
+        type: "object",
       },
     },
-
     useNative: {
       description: "Whether or not to use the native datepicker on mobile devices.",
       table: {
         type: { summary: "boolean" },
       },
       control: "boolean",
-    },
-    onChange: {
-      description: "Sideeffect to be run when a date is selected.",
-      table: {
-        type: { summary: "(date: Date | undefined) => void" },
-      },
     },
     colorScheme: {
       description: "Color scheme",
@@ -151,6 +164,15 @@ const meta: Meta<typeof KvibDatepicker> = {
       options: ["blue", "green"],
       control: { type: "radio" },
     },
+
+    // Fjern støy fra kontrollpanelet i Storybook
+    _groupOpen: { table: { disable: true } },
+    _groupClosed: { table: { disable: true } },
+    _open: { table: { disable: true } },
+    _closed: { table: { disable: true } },
+    _complete: { table: { disable: true } },
+    _incomplete: { table: { disable: true } },
+    _current: { table: { disable: true } },
   },
 };
 
@@ -158,11 +180,6 @@ export default meta;
 type Story = StoryObj<typeof KvibDatepicker>;
 
 export const Preview: Story = {
-  args: {
-    placeholder: "Velg dato",
-    onChange: v => console.log("Du endret dato i Datepicker til " + v.target.value),
-    "aria-label": "Datepicker example",
-  },
   render: args => <KvibDatepicker {...args} />,
 };
 

--- a/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.stories.tsx
+++ b/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof KvibDatepicker> = {
     useNative: false,
     disableNavigation: false,
     showWeekNumber: false,
-    showOutsideDays: false,
+    showOutsideDays: true,
     showDropdownMonthYear: false,
     defaultSelected: undefined,
     defaultMonth: undefined,
@@ -49,6 +49,7 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "Size of input",
       table: {
         type: { summary: "lg | md | sm | xs" },
+        defaultValue: { summary: "md" },
       },
       options: ["lg", "md", "sm", "xs"],
       control: { type: "radio" },
@@ -57,6 +58,7 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "Variant",
       table: {
         type: { summary: "outline | filled | flushed | unstyled" },
+        defaultValue: { summary: "outlined" },
       },
       options: ["outline", "filled", "flushed", "unstyled"],
       control: { type: "radio" },
@@ -118,6 +120,7 @@ const meta: Meta<typeof KvibDatepicker> = {
         "Whether or not to show dropdowns for month and year selection. `fromDate` and `toDate` must be set.",
       table: {
         type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -125,6 +128,7 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "If set to true, navigation buttons (next/previous month) are hidden.",
       table: {
         type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -132,6 +136,7 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "Whether or not to show the days that fall outside the current month.",
       table: {
         type: { summary: "boolean" },
+        defaultValue: { summary: "true" },
       },
       control: "boolean",
     },
@@ -139,6 +144,7 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "Whether or not to display the week numbers.",
       table: {
         type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -152,6 +158,7 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "Whether or not to use the native datepicker on mobile devices.",
       table: {
         type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
       },
       control: "boolean",
     },
@@ -159,9 +166,9 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "Color scheme",
       table: {
         type: { summary: "blue | green" },
-        defaultValue: { summary: "blue" },
+        defaultValue: { summary: "green" },
       },
-      options: ["blue", "green"],
+      options: ["green", "blue"],
       control: { type: "radio" },
     },
 

--- a/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.stories.tsx
+++ b/apps/storybook/stories/components/skjemaelementer/datepicker/Datepicker.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta<typeof KvibDatepicker> = {
       description: "Variant",
       table: {
         type: { summary: "outline | filled | flushed | unstyled" },
-        defaultValue: { summary: "outlined" },
+        defaultValue: { summary: "outline" },
       },
       options: ["outline", "filled", "flushed", "unstyled"],
       control: { type: "radio" },
@@ -66,7 +66,7 @@ const meta: Meta<typeof KvibDatepicker> = {
     isRequired: {
       description: "Toggles if input should be required",
       table: {
-        type: { summary: "Boolean" },
+        type: { summary: "boolean" },
       },
       defaultValue: { summary: "false" },
       control: "boolean",

--- a/packages/react/src/datepicker/Datepicker.tsx
+++ b/packages/react/src/datepicker/Datepicker.tsx
@@ -272,7 +272,6 @@ const CustomDatepicker = ({
             captionLayout={showDropdownMonthYear ? "dropdown" : "label"}
             startMonth={fromDate}
             endMonth={toDate}
-            footer={`Selected: ${selectedDate ? formatDate(selectedDate) : "None"}`}
             required={isRequired}
             {...(fromDate && {
               disabled: {

--- a/packages/react/src/datepicker/Datepicker.tsx
+++ b/packages/react/src/datepicker/Datepicker.tsx
@@ -173,7 +173,7 @@ const CustomDatepicker = ({
 
   const formatDateInput = (dateStr: string): Date | undefined => {
     try {
-      const formats = ["dd.MM.yy", "dd.MM.yyyy", "dd/MM/yy", "dd/MM/yyyy"];
+      const formats = ["dd.MM.yy", "dd.MM.yyyy", "dd/MM/yy", "dd/MM/yyyy", "dd-MM-yy", "dd-MM-yyyy"];
       for (const formatStr of formats) {
         const parsedDate = parse(dateStr, formatStr, new Date(), { locale: nb });
         if (!isNaN(parsedDate.getTime())) {

--- a/packages/react/src/datepicker/Datepicker.tsx
+++ b/packages/react/src/datepicker/Datepicker.tsx
@@ -96,14 +96,14 @@ export type DatepickerProps = Omit<InputProps, "colorScheme" | "max" | "min" | "
   colorScheme?: "blue" | "green";
 };
 
-export const Datepicker = forwardRef<DatepickerProps, "input">(({ onChange, useNative = true, ...props }, ref) => {
+export const Datepicker = forwardRef<DatepickerProps, "input">(({ onChange, useNative = false, ...props }, ref) => {
   const KVInputProps = extractKVProps(props);
   const commonProps = getCommonInputProps(props);
   const defaultValue = props.defaultSelected ? formatDate(props.defaultSelected) : undefined;
   const isClient = typeof window === "object";
   const isMobile = isClient ? window.innerWidth < 480 : false;
 
-  if (isMobile && useNative)
+  if (isMobile || useNative)
     return (
       <KVInput
         ref={ref}
@@ -283,6 +283,9 @@ const CustomDatepicker = ({
                 after: toDate,
               },
             })}
+            {...(disabledDays && {
+              disabled: disabledDays,
+            })}
           />
         </PopoverContent>
       </Portal>
@@ -357,10 +360,10 @@ const css = (className: string, colorPalette: Record<number, string>) => {
   --rdp-week_number-font: 12px/1 sans-serif;
 
   /* Day buttons */
-  --rdp-day-width: 40px; /* Width of the day cells. */
-  --rdp-day-height: 40px; /* Height of the day cells. */
-  --rdp-day_button-height: var(--rdp-day-height); /* Height of the day buttons. */
-  --rdp-day_button-width: var(--rdp-day-width); /* Width of the day buttons. */
+  --rdp-day-width: 38px; /* Width of the day cells. */
+  --rdp-day-height: 38px; /* Height of the day cells. */
+  --rdp-day_button-height: calc(var(--rdp-day-height) + 2px); /* Height of the day buttons. */
+  --rdp-day_button-width: calc(var(--rdp-day-width) + 2px); /* Width of the day buttons. */
   --rdp-day_button-border-radius: 50%;
   --rdp-outside-opacity: 0.4; /* Opacity of the days outside the current month. */
   --rdp-disabled-opacity: 0.25; /* Opacity of the disabled days. */
@@ -374,6 +377,9 @@ const css = (className: string, colorPalette: Record<number, string>) => {
   }
 
   .rdp-day {
+    box-sizing: border-box;
+    height: var(--rdp-day_button-height);
+    width: var(--rdp-day_button-width);
     border-radius: var(--rdp-day_button-border-radius);
   }
 
@@ -385,6 +391,7 @@ const css = (className: string, colorPalette: Record<number, string>) => {
   .rdp-selected {
     background-color: var(--rdp-accent-color);
     color: white;
+    box-sizing: border-box;
   }
 
   /* Navigation buttons */
@@ -416,16 +423,23 @@ const css = (className: string, colorPalette: Record<number, string>) => {
     font-weight: 700;
     text-align: center;
     height: var(--rdp-day_button-height);
+    width: var(--rdp-day_button-width);
     text-transform: uppercase;
   }
 
+  .rdp-day_button {
+  width: 100%;
+  height: 100%;
+  }
+
+
   .rdp-week_number {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-sizing: content-box;
-    width: var(--rdp-day_button-width);
+    vertical-align: baseline;
+    transform: translateY(50%);
+    text-align: center;
     height: var(--rdp-day_button-height);
+    width: var(--rdp-day_button-width);
+    line-height: 2px;
   }
 
   /* Month caption */


### PR DESCRIPTION
Gir et lite løft til Datepicker for å støtte det å skrive inn datoer i tekstfeltet igjen. Her støttes det nå flere skrivemåter hvor 29.10.24 blir tolket som 29.10.2024, og det samme gjelder for 29/10/24 og 29/10/2024. `onChange` som sendes inn til komponenten trigges både ved bruk av inputfelt og gjennom valg av dato i kalenderen, i tillegg til på `onBlur` når man fjerner fokus fra tekstfeltet.