### PR TITLE
Legger til menuPlacement prop for SearchAsync

### DIFF
--- a/.changeset/metal-coins-fly.md
+++ b/.changeset/metal-coins-fly.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Legger til menuPlacement prop for SearchAsync

--- a/apps/storybook/stories/components/search/search-async/SearchAsync.stories.tsx
+++ b/apps/storybook/stories/components/search/search-async/SearchAsync.stories.tsx
@@ -128,6 +128,14 @@ const meta: Meta<typeof KvibSearchAsync> = {
       },
       control: "text",
     },
+    menuPlacement: {
+      table: {
+        type: { summary: "bottom | top | auto" },
+        defaultValue: { summary: "bottom" },
+      },
+      options: ["bottom", "top", "auto"],
+      control: { type: "radio" },
+    },
   },
   args: { onChange: undefined, loadOptions: undefined },
 };

--- a/packages/react/src/search-async/SearchAsync.tsx
+++ b/packages/react/src/search-async/SearchAsync.tsx
@@ -10,6 +10,7 @@ import {
   AsyncSelect as ReactSearch,
   SizeProp,
   Variant,
+  MenuPlacement,
 } from "chakra-react-select";
 
 export type SearchAsyncElement<T> = SelectInstance<T, boolean, GroupBase<T>>;
@@ -57,6 +58,9 @@ export type BaseProps<T> = {
 
   /** Function to map inputValue to a text output when no options are loaded */
   noOptionsMessage?: ((obj: { inputValue: string }) => ReactNode) | undefined;
+
+  /** Default placement of the menu in relation to the control. 'auto' will flip when there isn't enough space below the control. */
+  menuPlacement: MenuPlacement;
 
   /** Variable to override the selected value of the component. Null resets the component and undefined  is ignored. When in use update value from the onChange function */
   value?: T | null;
@@ -110,6 +114,7 @@ const SearchAsyncNoRef = <T extends unknown>(
     noOptionsMessage,
     isDisabled,
     focusBorderColor,
+    menuPlacement = "bottom",
     value,
     optionLabelFormatter,
   }: SearchAsyncProps<T>,
@@ -161,6 +166,7 @@ const SearchAsyncNoRef = <T extends unknown>(
       isMulti={isMulti}
       isDisabled={isDisabled}
       focusBorderColor={focusBorderColor}
+      menuPlacement={menuPlacement}
       value={value}
       ref={ref}
     />

--- a/packages/react/src/search-async/SearchAsync.tsx
+++ b/packages/react/src/search-async/SearchAsync.tsx
@@ -60,7 +60,7 @@ export type BaseProps<T> = {
   noOptionsMessage?: ((obj: { inputValue: string }) => ReactNode) | undefined;
 
   /** Default placement of the menu in relation to the control. 'auto' will flip when there isn't enough space below the control. */
-  menuPlacement: MenuPlacement;
+  menuPlacement?: MenuPlacement;
 
   /** Variable to override the selected value of the component. Null resets the component and undefined  is ignored. When in use update value from the onChange function */
   value?: T | null;


### PR DESCRIPTION
# Beskrivelse

Legger til menuPlacement som en prop for SearchAsync så man kan velge om menyen skal være over, under eller auto (den siden som har plass). 

# Sjekkliste

<!-- Sjekk av disse punktene for hver endring. Disse utgjør et minimum av sjekker som skal være gjennomført før PR-en merges. For mer informasjon om hvordan du kan bidra med kode til designbiblioteket, se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-hurtigveiledning--docs>

- [ ] Alle tester har kjørt, og er grønne.
- [ ] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [ ] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [ ] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [ ] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [ ] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
