### PR TITLE
Markerer flere komponenter som deprecated

### DIFF
--- a/.changeset/unlucky-laws-whisper.md
+++ b/.changeset/unlucky-laws-whisper.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Endrer måten komponenter blir markert som deprecated slik at man fra nå av vil få advarseler om slike komponenter i IDE-en.

--- a/apps/storybook/stories/components/accordion/Accordion.stories.tsx
+++ b/apps/storybook/stories/components/accordion/Accordion.stories.tsx
@@ -14,7 +14,6 @@ const meta: Meta<typeof Accordion> = {
   parameters: {
     docs: {
       story: { inline: true },
-      canvas: { sourceState: "hidden" },
     },
   },
 };

--- a/packages/react/src/accordion/index.ts
+++ b/packages/react/src/accordion/index.ts
@@ -29,8 +29,4 @@ export type {
   AccordionRootProviderProps,
 } from "@chakra-ui/react";
 
-/** @deprecated Bruk AccordionItemTrigger istedenfor */
-export { AccordionItemTrigger as AccordionButton } from "@/components/ui/accordion";
-
-/** @deprecated Bruk AccordionItemContent istedenfor */
-export { AccordionItemContent as AccordionPanel } from "@/components/ui/accordion";
+export { AccordionButton, AccordionPanel } from "@/components/ui/accordion";

--- a/packages/react/src/alert/index.ts
+++ b/packages/react/src/alert/index.ts
@@ -10,5 +10,4 @@ export type {
   useAlertStyles,
 } from "@chakra-ui/react";
 
-/** @deprecated Bruk AlertIndicator istedenfor */
-export { AlertIndicator as AlertIcon } from "@chakra-ui/react";
+export { AlertIcon } from "@/components/ui/alert";

--- a/packages/react/src/checkbox-card/index.ts
+++ b/packages/react/src/checkbox-card/index.ts
@@ -1,4 +1,4 @@
-export { CheckboxCard, CheckboxCardIndicator } from "@/components/ui/checkbox-card";
+export { CheckboxCard, CheckboxCardIcon, CheckboxCardIndicator } from "@/components/ui/checkbox-card";
 export {
   CheckboxCardAddon,
   CheckboxCardContent,
@@ -26,6 +26,3 @@ export type {
   CheckboxCardRootProps,
   CheckboxCardRootProviderProps,
 } from "@chakra-ui/react";
-
-/** @deprecated Bruk CheckboxCardIndicator istedenfor */
-export { CheckboxCardIndicator as CheckboxCardIcon } from "@/components/ui/checkbox-card";

--- a/packages/react/src/components/ui/accordion.tsx
+++ b/packages/react/src/components/ui/accordion.tsx
@@ -29,6 +29,24 @@ export const AccordionItemTrigger = React.forwardRef<HTMLButtonElement, Accordio
   },
 );
 
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use AccordionItemTrigger instead
+ *
+ * Before:
+ *
+ * `<AccordionButton />`
+ *
+ * After:
+ *
+ * `<AccordionItemTrigger />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AccordionButton = AccordionItemTrigger;
+
 interface AccordionItemContentProps extends Accordion.ItemContentProps {}
 
 export const AccordionItemContent = React.forwardRef<HTMLDivElement, AccordionItemContentProps>(
@@ -40,6 +58,24 @@ export const AccordionItemContent = React.forwardRef<HTMLDivElement, AccordionIt
     );
   },
 );
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use AccordionItemContent instead
+ *
+ * Before:
+ *
+ * `<AccordionPanel />`
+ *
+ * After:
+ *
+ * `<AccordionItemContent />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AccordionPanel = AccordionItemContent;
 
 export const AccordionRoot = Accordion.Root;
 export const AccordionItem = Accordion.Item;

--- a/packages/react/src/components/ui/alert.tsx
+++ b/packages/react/src/components/ui/alert.tsx
@@ -31,3 +31,21 @@ export const Alert = React.forwardRef<HTMLDivElement, AlertProps>(function Alert
     </ChakraAlert.Root>
   );
 });
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use AlertIndicator instead
+ *
+ * Before:
+ *
+ * `<AlertIcon />`
+ *
+ * After:
+ *
+ * `<AlertIndicator />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AlertIcon = ChakraAlert.Indicator;

--- a/packages/react/src/components/ui/checkbox-card.tsx
+++ b/packages/react/src/components/ui/checkbox-card.tsx
@@ -47,3 +47,21 @@ export const CheckboxCard = React.forwardRef<HTMLInputElement, CheckboxCardProps
 });
 
 export const CheckboxCardIndicator = ChakraCheckboxCard.Indicator;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use CheckboxCardIndicator instead
+ *
+ * Before:
+ *
+ * `<CheckboxCardIcon />`
+ *
+ * After:
+ *
+ * `<CheckboxCardIndicator />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const CheckboxCardIcon = ChakraCheckboxCard.Indicator;

--- a/packages/react/src/components/ui/dialog.tsx
+++ b/packages/react/src/components/ui/dialog.tsx
@@ -44,3 +44,291 @@ export const DialogTitle = ChakraDialog.Title;
 export const DialogDescription = ChakraDialog.Description;
 export const DialogTrigger = ChakraDialog.Trigger;
 export const DialogActionTrigger = ChakraDialog.ActionTrigger;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use Dialog instead
+ *
+ * Before:
+ *
+ * `<Modal />`
+ *
+ * After:
+ *
+ * `<Dialog />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const Modal = DialogRoot;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogBackdrop instead
+ *
+ * Before:
+ *
+ * `<ModalOverlay />`
+ *
+ * After:
+ *
+ * `<DialogBackdrop />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalOverlay = DialogBackdrop;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogCloseTrigger instead
+ *
+ * Before:
+ *
+ * `<ModalCloseButton />`
+ *
+ * After:
+ *
+ * `<DialogCloseTrigger />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalCloseButton = DialogCloseTrigger;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogContent instead
+ *
+ * Before:
+ *
+ * `<ModalContent />`
+ *
+ * After:
+ *
+ * `<DialogContent />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalContent = DialogContent;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogFooter instead
+ *
+ * Before:
+ *
+ * `<ModalFooter />`
+ *
+ * After:
+ *
+ * `<DialogFooter />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalFooter = DialogFooter;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogHeader instead
+ *
+ * Before:
+ *
+ * `<ModalHeader />`
+ *
+ * After:
+ *
+ * `<DialogHeader />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalHeader = DialogHeader;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogTrigger instead
+ *
+ * Before:
+ *
+ * `<ModalTrigger />`
+ *
+ * After:
+ *
+ * `<DialogTrigger />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalTrigger = DialogTrigger;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogDescription instead
+ *
+ * Before:
+ *
+ * `<ModalDescription />`
+ *
+ * After:
+ *
+ * `<DialogDescription />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalDescription = DialogDescription;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogBody instead
+ *
+ * Before:
+ *
+ * `<ModalBody />`
+ *
+ * After:
+ *
+ * `<DialogBody />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalBody = DialogBody;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogTitle instead
+ *
+ * Before:
+ *
+ * `<ModalTitle />`
+ *
+ * After:
+ *
+ * `<DialogTitle />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const ModalTitle = DialogTitle;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use Dialog instead
+ *
+ * Before:
+ *
+ * `<AlertDialog />`
+ *
+ * After:
+ *
+ * `<Dialog />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AlertDialog = DialogRoot;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogCloseTrigger instead
+ *
+ * Before:
+ *
+ * `<AlertDialogCloseButton />`
+ *
+ * After:
+ *
+ * `<DialogCloseTrigger />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AlertDialogCloseButton = DialogActionTrigger;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogContent instead
+ *
+ * Before:
+ *
+ * `<AlertDialogContent />`
+ *
+ * After:
+ *
+ * `<DialogContent />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AlertDialogContent = DialogContent;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogFooter instead
+ *
+ * Before:
+ *
+ * `<AlertDialogFooter />`
+ *
+ * After:
+ *
+ * `<DialogFooter />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AlertDialogFooter = DialogFooter;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogHeader instead
+ *
+ * Before:
+ *
+ * `<AlertDialogHeader />`
+ *
+ * After:
+ *
+ * `<DialogHeader />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AlertDialogHeader = DialogHeader;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use DialogBackdrop instead
+ *
+ * Before:
+ *
+ * `<AlertDialogOverlay />`
+ *
+ * After:
+ *
+ * `<DialogBackdrop />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const AlertDialogOverlay = DialogBackdrop;

--- a/packages/react/src/components/ui/field.tsx
+++ b/packages/react/src/components/ui/field.tsx
@@ -1,3 +1,4 @@
+import { FieldErrorText, FieldHelperText, FieldLabel } from "@/field";
 import { Field as ChakraField } from "@chakra-ui/react";
 import * as React from "react";
 
@@ -24,3 +25,75 @@ export const Field = React.forwardRef<HTMLDivElement, FieldProps>(function Field
     </ChakraField.Root>
   );
 });
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use Field instead
+ *
+ * Before:
+ *
+ * `<FormControl />`
+ *
+ * After:
+ *
+ * `<Field />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const FormControl = Field;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use the label prop on the root component or FieldLabel instead
+ *
+ * Before:
+ *
+ * `<FormLabel />`
+ *
+ * After:
+ *
+ * `<Field label="..." />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const FormLabel = FieldLabel;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use the helperText prop on the root component or FieldHelperText instead
+ *
+ * Before:
+ *
+ * `<FormHelperText />`
+ *
+ * After:
+ *
+ * `<Field helperText="..." />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const FormHelperText = FieldHelperText;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use the errorText prop on the root component or FieldErrorText instead
+ *
+ * Before:
+ *
+ * `<FormErrorMessage />`
+ *
+ * After:
+ *
+ * `<Field errorText="..." />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const FormErrorMessage = FieldErrorText;

--- a/packages/react/src/components/ui/popover.tsx
+++ b/packages/react/src/components/ui/popover.tsx
@@ -92,3 +92,39 @@ export const PopoverTrigger = React.forwardRef<HTMLButtonElement, ChakraPopover.
     return <ChakraPopover.Trigger ref={ref} colorPalette={colorPalette} {...props} />;
   },
 );
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use PopoverTrigger instead
+ *
+ * Before:
+ *
+ * `<PopoverButton />`
+ *
+ * After:
+ *
+ * `<PopoverTrigger />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const PopoverButton = PopoverTrigger;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use PopoverCloseTrigger instead
+ *
+ * Before:
+ *
+ * `<PopoverCloseButton />`
+ *
+ * After:
+ *
+ * `<PopoverCloseTrigger />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const PopoverCloseButton = PopoverCloseTrigger;

--- a/packages/react/src/components/ui/radio-card.tsx
+++ b/packages/react/src/components/ui/radio-card.tsx
@@ -49,3 +49,21 @@ export const RadioCardItem = React.forwardRef<HTMLInputElement, RadioCardItemPro
 export const RadioCardRoot = RadioCard.Root;
 export const RadioCardLabel = RadioCard.Label;
 export const RadioCardItemIndicator = RadioCard.ItemIndicator;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use RadioCardItemIndicator instead
+ *
+ * Before:
+ *
+ * `<RadioCardItemIcon />`
+ *
+ * After:
+ *
+ * `<RadioCardItemIndicator />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const RadioCardItemIcon = RadioCardItemIndicator;

--- a/packages/react/src/components/ui/separator.tsx
+++ b/packages/react/src/components/ui/separator.tsx
@@ -1,0 +1,19 @@
+import { Separator } from "@/separator";
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use Separator instead
+ *
+ * Before:
+ *
+ * `<Divider />`
+ *
+ * After:
+ *
+ * `<Separator />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const Divider = Separator;

--- a/packages/react/src/components/ui/table.tsx
+++ b/packages/react/src/components/ui/table.tsx
@@ -1,0 +1,126 @@
+import { TableBody, TableCell, TableColumnHeader, TableFooter, TableHeader, TableRow, TableScrollArea } from "@/table";
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use TableHeader instead
+ *
+ * Before:
+ *
+ * `<Thead />`
+ *
+ * After:
+ *
+ * `<TableHeader />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const Thead = TableHeader;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use TableBody instead
+ *
+ * Before:
+ *
+ * `<Tbody />`
+ *
+ * After:
+ *
+ * `<TableBody />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const Tbody = TableBody;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use TableRow instead
+ *
+ * Before:
+ *
+ * `<Tr />`
+ *
+ * After:
+ *
+ * `<TableRow />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const Tr = TableRow;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use TableCell instead
+ *
+ * Before:
+ *
+ * `<Td />`
+ *
+ * After:
+ *
+ * `<TableCell />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const Td = TableCell;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use TableColumnHeader instead
+ *
+ * Before:
+ *
+ * `<Th />`
+ *
+ * After:
+ *
+ * `<TableColumnHeader />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const Th = TableColumnHeader;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use TableFooter instead
+ *
+ * Before:
+ *
+ * `<Tfoot />`
+ *
+ * After:
+ *
+ * `<TableFooter />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const Tfoot = TableFooter;
+
+/**
+ * @deprecated
+ *
+ * This component has been deprecated, please use TableScrollArea instead
+ *
+ * Before:
+ *
+ * `<TableOverflow />`
+ *
+ * After:
+ *
+ * `<TableScrollArea />`
+ *
+ * @deprecatedSince 5.0.0
+ *
+ */
+export const TableOverflow = TableScrollArea;

--- a/packages/react/src/dialog/index.ts
+++ b/packages/react/src/dialog/index.ts
@@ -5,6 +5,7 @@ export {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogOverlay,
+  DialogRoot as Dialog,
   DialogActionTrigger,
   DialogBackdrop,
   DialogBody,

--- a/packages/react/src/dialog/index.ts
+++ b/packages/react/src/dialog/index.ts
@@ -1,5 +1,10 @@
 export {
-  DialogRoot as Dialog,
+  AlertDialog,
+  AlertDialogCloseButton,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
   DialogActionTrigger,
   DialogBackdrop,
   DialogBody,
@@ -11,6 +16,16 @@ export {
   DialogRoot,
   DialogTitle,
   DialogTrigger,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  ModalTitle,
+  ModalTrigger,
 } from "@/components/ui/dialog";
 
 export { Dialog as KvibDialog, useDialog, useDialogContext, useDialogStyles } from "@chakra-ui/react";
@@ -28,51 +43,3 @@ export type {
   DialogTitleProps,
   DialogTriggerProps,
 } from "@chakra-ui/react";
-
-/** @deprecated Bruk Dialog istedenfor */
-export { DialogRoot as Modal } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogBackdrop istedenfor */
-export { DialogBackdrop as ModalOverlay } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogCloseTrigger istedenfor */
-export { DialogCloseTrigger as ModalCloseButton } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogContent istedenfor */
-export { DialogContent as ModalContent } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogFooter istedenfor */
-export { DialogFooter as ModalFooter } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogHeader istedenfor */
-export { DialogHeader as ModalHeader } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogTrigger istedenfor */
-export { DialogTrigger as ModalTrigger } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogDescription istedenfor */
-export { DialogDescription as ModalDescription } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogBody istedenfor */
-export { DialogBody as ModalBody } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogTitle istedenfor */
-export { DialogTitle as ModalTitle } from "@/components/ui/dialog";
-
-/** @deprecated Bruk Dialog istedenfor */
-export { DialogRoot as AlertDialog } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogCloseTrigger istedenfor */
-export { DialogActionTrigger as AlertDialogCloseButton } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogContent istedenfor */
-export { DialogContent as AlertDialogContent } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogFooter istedenfor */
-export { DialogFooter as AlertDialogFooter } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogHeader istedenfor */
-export { DialogHeader as AlertDialogHeader } from "@/components/ui/dialog";
-
-/** @deprecated Bruk DialogBackdrop istedenfor */
-export { DialogBackdrop as AlertDialogOverlay } from "@/components/ui/dialog";

--- a/packages/react/src/field/index.ts
+++ b/packages/react/src/field/index.ts
@@ -18,14 +18,4 @@ export type {
   FieldRequiredIndicatorProps,
 } from "@chakra-ui/react";
 
-/** @deprecated Bruk Field istedenfor */
-export { Field as FormControl } from "@/components/ui/field";
-
-/** @deprecated Bruk FieldLabel istedenfor */
-export { FieldLabel as FormLabel } from "@chakra-ui/react";
-
-/** @deprecated Bruk FieldHelperText istedenfor */
-export { FieldHelperText as FormHelperText } from "@chakra-ui/react";
-
-/** @deprecated Bruk FieldErrorText istedenfor */
-export { FieldErrorText as FormErrorMessage } from "@chakra-ui/react";
+export { FormControl, FormErrorMessage, FormHelperText, FormLabel } from "@/components/ui/field";

--- a/packages/react/src/popover/index.ts
+++ b/packages/react/src/popover/index.ts
@@ -29,8 +29,4 @@ export type {
   usePopoverStyles,
 } from "@chakra-ui/react";
 
-/** @deprecated Bruk PopoverTrigger istedenfor */
-export { PopoverTrigger as PopoverButton } from "@/components/ui/popover";
-
-/** @deprecated Bruk PopoverCloseTrigger istedenfor */
-export { PopoverCloseTrigger as PopoverCloseButton } from "@/components/ui/popover";
+export { PopoverButton, PopoverCloseButton } from "@/components/ui/popover";

--- a/packages/react/src/radio-card/index.ts
+++ b/packages/react/src/radio-card/index.ts
@@ -31,5 +31,4 @@ export type {
   RadioCardValueChangeDetails,
 } from "@chakra-ui/react";
 
-/** @deprecated Bruk RadioCardItemIndicator istedenfor */
-export { RadioCardItemIndicator as RadioCardItemIcon } from "@/components/ui/radio-card";
+export { RadioCardItemIcon } from "@/components/ui/radio-card";

--- a/packages/react/src/separator/index.ts
+++ b/packages/react/src/separator/index.ts
@@ -1,5 +1,4 @@
 export { Separator, SeparatorPropsProvider } from "@chakra-ui/react";
 export type { SeparatorProps } from "@chakra-ui/react";
 
-/** @deprecated Bruk Separator istedenfor */
-export { Separator as Divider } from "@chakra-ui/react";
+export { Divider } from "@/components/ui/separator";

--- a/packages/react/src/table/index.ts
+++ b/packages/react/src/table/index.ts
@@ -29,23 +29,4 @@ export type {
   TableScrollAreaProps,
 } from "@chakra-ui/react";
 
-/** @deprecated Bruk TableHeader istedenfor */
-export { TableHeader as Thead } from "@chakra-ui/react";
-
-/** @deprecated Bruk TableBody istedenfor */
-export { TableBody as Tbody } from "@chakra-ui/react";
-
-/** @deprecated Bruk TableRow istedenfor */
-export { TableRow as Tr } from "@chakra-ui/react";
-
-/** @deprecated Bruk TableCell istedenfor */
-export { TableCell as Td } from "@chakra-ui/react";
-
-/** @deprecated Bruk TableColumnHeader istedenfor */
-export { TableColumnHeader as Th } from "@chakra-ui/react";
-
-/** @deprecated Bruk TableFooter istedenfor */
-export { TableFooter as Tfoot } from "@chakra-ui/react";
-
-/** @deprecated Bruk TableScrollArea istedenfor */
-export { TableScrollArea as TableOverflow } from "@chakra-ui/react";
+export { TableOverflow, Tbody, Td, Tfoot, Th, Thead, Tr } from "@/components/ui/table";


### PR DESCRIPTION
En rekke komponenter skulle vært markert som `@deprecated` fra før, men dette virket ikke siden det var selve aliasene som ble markert istedenfor at man oppretter et nytt objekt og setter dette som deprecated (ref. [denne tråden](https://github.com/palantir/tslint/issues/3751#issuecomment-370265475). Nå er dette fikset