### PR TITLE
chore: Downgrade react dependency to >= 18

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,8 +24,8 @@
     "@chakra-ui/cli": "3.16.1",
     "@types/react": "19.1.2",
     "@types/react-dom": "19.1.2",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0",
     "tsup": "^8.4.0",
     "typescript": "5.8.3"
   },


### PR DESCRIPTION
# Beskrivelse

Ser ikke ut som KVIB benytter seg av react 19, så overlater peer dependency resolution til å tillate versjoner fra og med React 18
