### PR TITLE
Allow React 18 and up as peer dependency

### DIFF
--- a/.changeset/dark-moments-stop.md
+++ b/.changeset/dark-moments-stop.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Allow a broader range of React as peer dependency


### PR DESCRIPTION
# Beskrivelse

Trigger en versjonsoppdatering av forrige PR som åpnet opp React peerDependency til å tillate versjon 18 og oppover.

https://github.com/kartverket/kvib/pull/1002