### PR TITLE
Små forbedringer på Header

### DIFF
--- a/.changeset/purple-paws-vanish.md
+++ b/.changeset/purple-paws-vanish.md
@@ -1,0 +1,8 @@
+---
+"@kvib/react": patch
+---
+
+Header:
+- Aligner content i drawer til venstre istedenfor midten
+- Viser alltid content slik at det kan velges fra brukeren av komponenten
+- Grupperer menyknapp og content slik at det kun blir to deler i headeren

--- a/packages/react/src/header/Header.tsx
+++ b/packages/react/src/header/Header.tsx
@@ -65,7 +65,6 @@ export const Header = (props: HeaderProps) => {
   const logoVerticalSize = isSm ? 70 : 100;
   const headerSize = isSm ? 70 : 90;
   const justify = justifyContent && isCollapse ? "space-between" : justifyContent;
-  const showContent = !isCollapse;
   const [isOpen, onToggle] = useToggle();
   const showMenuButtonElement = (content && (isCollapse || isOpen)) || showMenuButton;
   const handleClick = onMenuButtonClick || onToggle;
@@ -118,28 +117,30 @@ export const Header = (props: HeaderProps) => {
             )}
           </Flex>
 
-          {showContent && content}
+          <>
+            {content}
 
-          {showMenuButtonElement &&
-            (isCollapse ? (
-              <IconButton
-                aria-label={isOpen ? "Lukk meny" : "Åpne meny"}
-                aria-expanded={isOpen}
-                icon={isOpen ? "close" : "menu"}
-                onClick={handleClick}
-                variant="plain"
-              />
-            ) : (
-              <Button
-                variant="plain"
-                rightIcon={isOpen ? "close" : "menu"}
-                onClick={handleClick}
-                aria-expanded={isOpen}
-                aria-controls="navigation-menu"
-              >
-                Meny
-              </Button>
-            ))}
+            {showMenuButtonElement &&
+              (isCollapse ? (
+                <IconButton
+                  aria-label={isOpen ? "Lukk meny" : "Åpne meny"}
+                  aria-expanded={isOpen}
+                  icon={isOpen ? "close" : "menu"}
+                  onClick={handleClick}
+                  variant="plain"
+                />
+              ) : (
+                <Button
+                  variant="plain"
+                  rightIcon={isOpen ? "close" : "menu"}
+                  onClick={handleClick}
+                  aria-expanded={isOpen}
+                  aria-controls="navigation-menu"
+                >
+                  Meny
+                </Button>
+              ))}
+          </>
         </Flex>
       </Box>
 
@@ -157,6 +158,7 @@ export const Header = (props: HeaderProps) => {
               gap={10}
               role="navigation"
               aria-label="Hovedmeny"
+              alignItems="start"
             >
               {menuContent}
             </VStack>


### PR DESCRIPTION
# Beskrivelse

- Aligner content i dropdown til venstre istedenfor midten
- Viser alltid content slik at det kan velges fra brukeren av komponenten
- Grupperer menyknapp og content slik at det kun blir to deler i headeren

# Sjekkliste

- [x] Alle tester har kjørt, og er grønne.
- [ x Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [x] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [ ] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [x] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [x] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
