### PR TITLE
Fikser styling på mobil i Header

### DIFF
--- a/.changeset/many-otters-float.md
+++ b/.changeset/many-otters-float.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": minor
+---
+
+Fikser styling på mobilversjon av Header-komponenten

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,5 +1,8 @@
 import type { StorybookConfig } from "@storybook/react-vite";
-import { dirname, join } from "path";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 /**
  * This function is used to resolve the absolute path of a package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
     },
     "apps/storybook": {
       "name": "@kvib/storybook",
-      "version": "1.1.4",
+      "version": "1.1.7",
       "license": "ISC",
       "dependencies": {
         "@fontsource-variable/mulish": "^5.2.5"
@@ -20300,7 +20300,7 @@
     },
     "packages/react": {
       "name": "@kvib/react",
-      "version": "5.2.2",
+      "version": "6.0.4",
       "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "3.19.1",

--- a/packages/react/src/header/Header.tsx
+++ b/packages/react/src/header/Header.tsx
@@ -75,7 +75,13 @@ export const Header = (props: HeaderProps) => {
       <Logo
         label={logoAltText}
         variant={logoVariant}
-        size={logoVariant == "horizontal" ? logoHorizontalSize : logoVariant == "vertical" ? logoVerticalSize : logoSymbolSize}
+        size={
+          logoVariant == "horizontal"
+            ? logoHorizontalSize
+            : logoVariant == "vertical"
+              ? logoVerticalSize
+              : logoSymbolSize
+        }
       />
     );
   };
@@ -92,7 +98,7 @@ export const Header = (props: HeaderProps) => {
           justifyContent={justify}
           gap={gap}
         >
-          <Flex alignItems="flex-end" gap={5}>
+          <Flex alignItems={logoVariant === "horizontal" ? "flex-end" : "center"} gap={5}>
             {logoLinkDisabled ? (
               <HeaderLogo />
             ) : (
@@ -101,7 +107,7 @@ export const Header = (props: HeaderProps) => {
               </Link>
             )}
             {title && (
-              <HStack marginBottom="3px" gap={5}>
+              <HStack marginBottom={logoVariant === "horizontal" ? "3px" : "0"} gap={5}>
                 <Separator orientation="vertical" height="28px" />
                 {titleLink ? (
                   <Link href={titleLink} variant="plain">


### PR DESCRIPTION
Midtstiller tittel dersom logovarianten er noe annet enn horizontal

# Beskrivelse

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->

Endrer styling slik at tittel blir midstilt dersom logovariant er symbol. Med horizontal blir den som før.

_Gjorde en liten endring i main for å få prosjektet til å bygge med node 22+_

Før:
<img width="555" height="86" alt="image" src="https://github.com/user-attachments/assets/4abcbbab-ac1f-4276-bc09-b67f696cae78" />

Etter:
<img width="532" height="92" alt="image" src="https://github.com/user-attachments/assets/84432871-78b7-43fe-8301-4dad109bd5f2" />


# Sjekkliste

- [x] Alle tester har kjørt, og er grønne.
- [x] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [x] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [x] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [x] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [ ] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
