### PR TITLE
Fikse feil med maksbredde på Header

### DIFF
--- a/.changeset/legal-places-ask.md
+++ b/.changeset/legal-places-ask.md
@@ -1,0 +1,5 @@
+---
+"@kvib/react": patch
+---
+
+Fikser at contentMaxWidth Header ble for stor pga padding

--- a/packages/react/src/header/Header.tsx
+++ b/packages/react/src/header/Header.tsx
@@ -65,6 +65,7 @@ export const Header = (props: HeaderProps) => {
   const logoVerticalSize = isSm ? 70 : 100;
   const logoSymbolSize = isSm ? 33 : 37;
   const headerSize = isSm ? 70 : 90;
+  const headerPadding = 30;
   const justify = justifyContent && isCollapse ? "space-between" : justifyContent;
   const [isOpen, onToggle] = useToggle();
   const showMenuButtonElement = (content && (isCollapse || isOpen)) || showMenuButton;
@@ -90,9 +91,13 @@ export const Header = (props: HeaderProps) => {
     <Box>
       <Box bg="white" borderBottomWidth="1px" borderBottomColor="gray.200">
         <Flex
-          maxWidth={contentMaxWidth}
+          maxWidth={
+            typeof contentMaxWidth === "number"
+              ? contentMaxWidth + headerPadding * 2
+              : `calc(${contentMaxWidth} + (${headerPadding} * 2px))`
+          }
           margin="0 auto"
-          padding={30}
+          padding={headerPadding}
           height={headerSize}
           alignItems="center"
           justifyContent={justify}
@@ -161,7 +166,7 @@ export const Header = (props: HeaderProps) => {
               bg="white"
               borderBottomWidth="2px"
               borderBottomColor="gray.200"
-              padding={30}
+              padding={headerPadding}
               gap={10}
               role="navigation"
               aria-label="Hovedmeny"
@@ -180,7 +185,7 @@ export const Header = (props: HeaderProps) => {
             <DrawerBody>
               <VStack
                 id="navigation-menu"
-                padding={30}
+                padding={headerPadding}
                 gap={10}
                 align="stretch"
                 role="navigation"


### PR DESCRIPTION
# Beskrivelse

<!-- Skriv en kort beskrivelse for hva denne endringen innebærer, gjerne med skjermbilde -->
Fikser en feil som gjorde at maksbredden på header ble mindre enn det man satte, fordi paddingen ikke ble tatt med i beregningen. 1140px som default ble derfor ~ 1080px bredt, og da ga ikke propen veldig mening.

# Sjekkliste

<!-- Sjekk av disse punktene for hver endring. Disse utgjør et minimum av sjekker som skal være gjennomført før PR-en merges. For mer informasjon om hvordan du kan bidra med kode til designbiblioteket, se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-hurtigveiledning--docs>

- [ ] Alle tester har kjørt, og er grønne.
- [ ] Dersom det er lagt til ny funksjonalitet er det også lagt til stories og dokumentasjon på denne i storybook. Stories skal dekke de viktigste tilstandene visuelt, og blir blant annet brukt til å kjøre automatisk testing av universell utforming, i tillegg til dokumentasjon.
- [ ] Har sjekket PR-preview, som kommer som en egen lenke lenger ned i pull-request og gjort manuell testing av de viktigste endringene.
- [ ] Har lagt ut melding med lenke til PR i kanalen #gen-designsystem på slack.
- [ ] Har fått PR-en godkjent av et teammedlem i designsystemteamet eller et annet produktteam som bruker designsystemet (ikke eget team).
- [ ] Har lagt til changeset, dersom det er gjort endringer i react-pakka. Se https://design.kartverket.no/?path=/docs/for-utviklere-bidra-med-kode-publish--docs
- [ ] Ved store endringer, eller mulighet for utilsiktede sideeffekter: Har kjørt Chromatic-action, og sett igjennom at endringene ikke har uønskede sideeffekter. Se https://kartverket.atlassian.net/l/cp/MG5W191b for mer info om bruk av Chromatic.
