### PR TITLE
Create/update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,3 +8,15 @@ spec:
   type: website
   lifecycle: production
   owner: designsystem
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: kvib-react
+  tags:
+    - public
+spec:
+  type: library
+  owner: group:default/designsystem
+  lifecycle: production


### PR DESCRIPTION
Forslag: 

Kvib er også et react-bibliotek som mange frontend-applikasjoner bruker. Ved å legge det til som et library i kartverket.dev kan man be teamene som bruker det om å oppdatere sine frontend-apper til å si at de er avhengige av dette biblioteket.